### PR TITLE
feat(cli): taskx neon persist (safe, idempotent, dry-run default)

### DIFF
--- a/src/taskx/cli.py
+++ b/src/taskx/cli.py
@@ -465,17 +465,12 @@ def neon_persist(
             remove=remove,
             dry_run=not yes,
         )
-    except ValueError as exc:
-        # Malformed markers in the rc file; present a friendly error instead of a traceback.
+    except OSError as exc:
         if neon_enabled():
-            neon_console.print(
-                f"[bold red]Error:[/bold red] Failed to update rc file {path} due to malformed markers."
-            )
-            neon_console.print(f"[dim]{exc}[/dim]")
+            neon_console.print(f"[bold red]Error:[/bold red] {exc}")
         else:
-            print(f"Error: Failed to update rc file {path} due to malformed markers.")
-            print(exc)
-        raise typer.Exit(1)
+            print(f"Error: {exc}")
+        raise typer.Exit(1) from exc
 
     if neon_enabled():
         neon_console.print(f"[bold]Target:[/bold] {result.path}")


### PR DESCRIPTION
Summary:
- Adds taskx neon persist for safe shell RC persistence with managed markers.
- Default is --dry-run; requires --yes to write.
- Atomic write, timestamped backup, idempotent replace/remove.
- Adds unit tests for idempotence/remove/backup behavior.

Proof:
- uv run taskx neon persist --help
- uv run pytest -q (pass, local)

Reviewers: @codex @clauee @copilot
