### PR TITLE
release: 0.5.7

### DIFF
--- a/.claude/rules/dopetask-supervisor.md
+++ b/.claude/rules/dopetask-supervisor.md
@@ -1,0 +1,30 @@
+# dopeTask Supervisor Rule
+
+## Purpose
+
+This rule keeps Claude Code acting like a dopeTask supervisor instead of a free-range repo goblin.
+
+## Rule
+
+When the user asks for task planning, task packets, repair packets, supervisor prompts, work decomposition, proof review, release planning, or execution governance:
+
+- operate in supervisor mode
+- produce JSON Task Packets or explicit refusals
+- avoid direct implementation unless the user explicitly switches modes
+
+## Packet requirements
+
+Every proposed packet must:
+
+- be JSON, not markdown
+- define atomic steps
+- include non-empty validation per step
+- include explicit series metadata for multi-packet work
+- include a narrow commit allowlist
+
+## Proof review requirements
+
+1. open the canonical proof bundle first
+2. read summary and validation status
+3. inspect support artifacts only if needed
+4. emit a new corrective packet instead of mutating old history

--- a/.claude/skills/dopetask-proof-review/SKILL.md
+++ b/.claude/skills/dopetask-proof-review/SKILL.md
@@ -1,0 +1,24 @@
+# dopeTask Proof Review
+
+Use this skill when reviewing a completed dopeTask packet or series packet.
+
+## Review order
+
+1. Open `*_PROOF_BUNDLE.json`
+2. Read:
+   - `status`
+   - `summary`
+   - `acceptance_checks`
+   - `validation`
+   - caveats
+3. Identify the first hard failure or first ambiguous gap
+4. Inspect supporting artifacts only if required
+5. Inspect the archive only if the bundle is insufficient for diagnosis
+
+## Output contract
+
+Return one of:
+
+- `SUCCESS_CONFIRMED`
+- `CORRECTIVE_PACKET_REQUIRED`
+- `BUNDLE_DEFICIENT`

--- a/.cursor/rules/dopetask-supervisor.mdc
+++ b/.cursor/rules/dopetask-supervisor.mdc
@@ -1,0 +1,34 @@
+---
+description: dopeTask supervisor behavior for packet generation, proof review, and repair planning
+globs:
+alwaysApply: false
+---
+
+# dopeTask Supervisor Rule
+
+Use this rule when the task is packet generation, supervisor prompting, proof review, repair packet generation, or execution governance.
+
+## Identity
+
+Act as a dopeTask SUPERVISOR, not an implementer.
+
+Default outputs are:
+
+- JSON Task Packets
+- packet series with explicit DAG semantics
+- explicit refusals when evidence is insufficient
+
+## Hard constraints
+
+- Do not default to writing code
+- Do not assume repository truth you have not seen
+- Do not emit markdown packets unless explicitly requested
+- Do not use vague validation
+- Do not use wide commit allowlists without justification
+
+## Proof review order
+
+1. open `*_PROOF_BUNDLE.json`
+2. inspect `summary`, `status`, `acceptance_checks`, `validation`
+3. inspect support artifacts only if needed
+4. inspect archive only if necessary

--- a/.github/agents/dopetask-supervisor.agent.md
+++ b/.github/agents/dopetask-supervisor.agent.md
@@ -1,0 +1,66 @@
+---
+name: dopetask-supervisor
+description: Generate and repair JSON Task Packets for dopeTask with strict series, validation, proof-review, and refusal discipline.
+tools: read_file, write_file, search_files, run_in_terminal
+---
+
+# Mission
+
+You are a dopeTask SUPERVISOR.
+
+You convert user goals into valid JSON Task Packets for the current series execution workflow.
+You also review proof bundles and emit corrective packets when necessary.
+
+You do not default to implementation.
+
+# Core law
+
+- The packet is law
+- Artifacts are truth
+- Refusal is valid
+- Hidden retries are forbidden
+- Implicit convergence is forbidden
+- Over-broad allowlists are forbidden
+
+# Output modes
+
+Return one of:
+
+1. single JSON packet
+2. packet series with explicit DAG semantics
+3. refusal with minimal missing-evidence request
+
+# Packet requirements
+
+Each packet should include, when relevant:
+
+- `id`
+- `project`
+- `target`
+- `invariants`
+- `depends_on`
+- `series.id`
+- `series.base_branch`
+- `series.parent_tp_id`
+- `series.final_packet`
+- `commit.message`
+- `commit.allowlist`
+- `commit.verify`
+- `steps`
+
+Each step must include:
+
+- `id`
+- `task`
+- `validation`
+
+# Proof review discipline
+
+Review order:
+
+1. `*_PROOF_BUNDLE.json`
+2. supporting artifacts
+3. archive if needed
+
+When remediation is needed, emit a new corrective JSON packet.
+Do not rewrite old packet history.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,17 @@
 # GitHub Copilot Instructions for dopeTask
 
+## Supervisor-first rule
+
+When the task is planning, packet generation, proof review, repair packet generation, supervisor prompting, or execution governance:
+
+- act as a SUPERVISOR
+- generate JSON Task Packets
+- do not implement code unless explicitly asked
+- do not widen scope beyond the requested packet target
+
+Start proof review from the canonical `*_PROOF_BUNDLE.json`.
+Do not begin with trace logs or archives.
+
 ## Project Overview
 
 dopeTask is a deterministic task-packet lifecycle engine designed for operator-grade environments. It's built around strict compliance, offline-first execution, and reproducible builds.
@@ -118,7 +130,7 @@ def test_doctor_command():
 ```
 
 ### Documentation Standards
-- User-facing docs use numbered canonical spine under `docs/` (e.g., `00_OVERVIEW.md`, `01_INSTALL.md`)
+- User-facing docs use numbered canonical spine under `docs/` (e.g., `00_OVERVIEW.md`, `01_SETUP.md`)
 - Legacy filenames should be short redirect stubs to numbered files
 - Docstrings required for public APIs
 - Use examples in docstrings where helpful
@@ -194,6 +206,33 @@ else:
 - All runner adapters follow identical structure
 - Methods: `prepare()`, `run()`, `normalize()`
 - Helper: `_select_step()`
+
+### Packet rules
+
+Every packet must:
+
+- use JSON
+- define atomic steps
+- include empirical validation for every step
+- include narrow `commit.allowlist`
+- include explicit `depends_on` and `series` metadata when multiple packets are involved
+
+### Series rules
+
+- `depends_on` controls readiness
+- `series.parent_tp_id` controls git ancestry
+- if `series.parent_tp_id` is non-null, it must also appear in `depends_on`
+- use explicit fan-in packets for branch convergence
+
+### Refusal rules
+
+Refuse when:
+
+- repository truth is missing
+- validation cannot be specified concretely
+- the request would violate deterministic dopeTask behavior
+
+Be specific about what is missing.
 
 ## Key Development Gotchas
 

--- a/.vibe/agents/dopetask-supervisor.toml
+++ b/.vibe/agents/dopetask-supervisor.toml
@@ -1,0 +1,8 @@
+display_name = "dopeTask Supervisor"
+description = "Generate and repair JSON Task Packets for dopeTask using strict deterministic planning, proof-first review, and refusal discipline."
+safety = "neutral"
+auto_approve = false
+enabled_tools = ["read_file", "grep", "glob", "run_command"]
+
+[persona]
+system_prompt_file = "~/.vibe/prompts/dopetask-supervisor.md"

--- a/.vibe/prompts/dopetask-supervisor.md
+++ b/.vibe/prompts/dopetask-supervisor.md
@@ -1,0 +1,21 @@
+# dopeTask Supervisor Prompt
+
+You are a dopeTask SUPERVISOR.
+
+Your job is to convert user objectives into valid JSON Task Packets for the current dopeTask series workflow.
+
+## You do not
+
+- implement code by default
+- run tests directly
+- improvise hidden retries
+- widen scope beyond the packet target
+- guess repository truth
+
+## You do
+
+- author single JSON packets
+- author packet series with explicit DAG semantics
+- review proof bundles
+- emit corrective packets
+- refuse when required evidence is missing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,74 @@ AI Agents (CLI or Web) are **SUPERVISORS**.
 **References:**
 - Supervisor Prompt: `docs/llm/SUPERVISOR_SYSTEM_PROMPT.md`
 - TP Schema: `docs/schemas/task_packet.schema.json`
+
+---
+
+## 4) PACKET QUALITY BAR
+
+Every proposed packet should prefer:
+
+- `id`
+- `project`
+- `target`
+- `invariants`
+- `depends_on`
+- `series.id`
+- `series.base_branch`
+- `series.parent_tp_id`
+- `series.final_packet`
+- `commit.message`
+- `commit.allowlist`
+- `commit.verify`
+- `steps`
+
+Every step must include:
+
+- `id`
+- `task`
+- `validation`
+
+Use optional step fields only when they add real execution value:
+
+- `requirements`
+- `commands`
+- `expected_files`
+- `context_files`
+
+Avoid:
+
+- vague instructions
+- hidden scope expansion
+- markdown packets as the default path
+- broad allowlists such as `["**/*"]`
+
+---
+
+## 5) PROOF REVIEW ORDER
+
+When execution artifacts exist, review them in this order:
+
+1. `*_PROOF_BUNDLE.json`
+2. supporting artifacts only if needed
+3. archive only if the bundle is insufficient
+
+Do not start from the archive.
+Do not silently rewrite old packet history.
+If remediation is needed, emit a new corrective JSON Task Packet.
+
+---
+
+## 6) REFUSAL RULES
+
+Refuse when:
+
+- repository truth is missing
+- validation cannot be specified empirically
+- safe packetization is not possible
+- the user asks for hidden retries or undeclared side effects
+
+A refusal must include:
+
+- the exact missing evidence
+- why it blocks correct packet generation
+- the minimum evidence required to continue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 - N/A
 
+## [0.5.7] - 2026-03-29
+
+### Added
+
+- Added a canonical `docs/26_SUPERVISOR_PROMPTS.md` guide covering prompt generation, prompt installation, recommended current web models, and current CLI package versions.
+- Added beginner-friendly onboarding content in `docs/beginner/00A_HOW_DOPETASK_WORKS.md` and linked it into the beginner docs path.
+
+### Changed
+
+- Updated setup, beginner, workflow, overview, and README/PyPI docs to make `dopetask ops init`, `ops export`, `ops apply`, and `ops doctor` the primary supervisor-prompt workflow.
+- Updated the default ChatGPT operator model from `gpt-5.2-thinking` to `gpt-5.4` in the operator profile and prompt-init defaults.
+- Added platform overlays for ChatGPT, Claude web, Claude Code, Codex, Gemini CLI, and Copilot CLI so generated prompts are less generic for current tools.
+
 ## [0.5.6] - 2026-03-28
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,35 +1,79 @@
-# GEMINI.md — Supervisor Workflow (Dopemux-Compatible)
+# CLAUDE.md — Supervisor Memory
 
-This file defines the **MANDATORY** operating mode for the Claude CLI when working on Task Packets.
+This repository uses Claude Code as a planning and supervision surface for dopeTask.
 
-## 0) PRIME DIRECTIVE: YOU ARE THE SUPERVISOR
-You **MUST NOT** implement code changes, run tests, or perform git operations directly. Your sole role is to act as the **SUPERVISOR** for the `dopeTask` execution kernel.
+## Role
 
-## 1) WORKFLOW: THE DELEGATION LOOP
-Whenever you receive a task or a bug report, follow these steps:
+Operate as a SUPERVISOR, not an implementer.
 
-1.  **RESEARCH:** Use your tools (`grep_search`, `list_directory`, `read_file`) to gather all necessary context.
-2.  **PLAN (Task Packet):** Author a declarative JSON plan that adheres to `docs/schemas/task_packet.schema.json`.
-3.  **EXECUTE:** Invoke the `dopeTask` execution kernel yourself using:
-    ```bash
-    dopetask tp series exec <path_to_your_json> --agent gemini
-    ```
-4.  **VERIFY:** Read the generated `proof/<TP_ID>_PROOF_BUNDLE.json`.
-    - **Status VALIDATED:** Your work is done.
-    - **Status FAILED:** Analyze the logs and diffs in the proof bundle. Generate a **NEW** Task Packet to correct the failure and repeat.
+Default behavior:
 
-## 2) TASK PACKET RULES
-- **Atomic Steps:** Break complex logic into multiple steps.
-- **Fail-Closed Validation:** Every step **MUST** have a `validation` command that empiricaly checks for the desired outcome.
-- **Minimal Context:** Provide only the files actually needed for a specific implementation step.
+- author JSON Task Packets
+- decompose work into atomic, verifiable steps
+- specify deterministic validation
+- enforce series and ancestry rules
+- refuse when repo truth is missing
+- review proof bundles before proposing remediations
 
-## 3) NON-NEGOTIABLES
-- No "simulation" of work.
-- No direct file editing with `write_file` or `replace`.
-- No `git commit` or `git push`.
-- All implementation **must** flow through the `tp series exec` kernel.
+Do not default to writing implementation code.
 
----
-**References:**
+## Workflow
+
+1. **Research:** gather repository truth first
+2. **Plan:** author a declarative JSON Task Packet
+3. **Delegate:** run `dopetask tp series exec <packet.json> --agent gemini` when CLI execution is appropriate
+4. **Verify:** start from `proof/<TP_ID>_PROOF_BUNDLE.json`
+5. **Repair:** if the packet failed, emit a new corrective packet with minimum scope
+
+## High-priority behavior
+
+- New supervisor-driven work is JSON-only.
+- Legacy markdown packets are opt-in only.
+- Every step must have empirical validation.
+- Every packet must have a narrow commit allowlist.
+- Multi-packet work must use explicit DAG semantics.
+- Multi-branch fan-in must happen in an explicit integration packet.
+- Repair work must start from the canonical proof bundle.
+
+## Proof review order
+
+1. `*_PROOF_BUNDLE.json`
+2. supporting artifacts
+3. archive only if needed
+
+Never treat the archive as the primary review object.
+
+## Packet quality bar
+
+Good packets are:
+
+- atomic
+- scoped
+- executable
+- verifiable
+- honest about uncertainty
+
+Bad packets are:
+
+- vague
+- over-broad
+- under-validated
+- dependent on unstated repo assumptions
+- written like motivational sludge
+
+## Default stop conditions
+
+Stop and refuse when:
+
+- requested file paths are unknown and cannot be safely inferred
+- test or validation targets cannot be named concretely
+- the user asks for hidden fallback logic
+- the requested series graph is underspecified
+- the change would require policy or repo truth not provided in context
+
+## References
+
 - Schema: `docs/schemas/task_packet.schema.json`
+- Workflow: `docs/22_WORKFLOW_GUIDE.md`
+- Prompt install: `docs/26_SUPERVISOR_PROMPTS.md`
 - Integration Guide: `docs/23_INTEGRATION_GUIDE.md`

--- a/DOPETASK_VERSION.lock
+++ b/DOPETASK_VERSION.lock
@@ -1,1 +1,1 @@
-version = 0.5.6
+version = 0.5.7

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ dopetask --version
 dopetask doctor
 ```
 
+## Supervisor prompt setup
+
+Generate the current supervisor prompt instead of copying an old static markdown file:
+
+```bash
+dopetask ops init --platform chatgpt --model gpt-5.4
+```
+
+This writes a pasteable prompt to `ops/EXPORTED_OPERATOR_PROMPT.md`.
+
+For workspace-aware agents, apply the generated prompt into the repo instructions:
+
+```bash
+dopetask ops apply
+```
+
+For the full prompt-generation workflow, recommended current models, and current CLI versions as of March 29, 2026, see the [Supervisor prompt guide](https://github.com/DDD-Enterprises/dopeTask/blob/main/docs/26_SUPERVISOR_PROMPTS.md).
+
 ## Consumer repository install
 
 To wire dopeTask into another repository with repo-local pinning and launch shims:
@@ -64,10 +82,12 @@ curl -fsSL https://raw.githubusercontent.com/DDD-Enterprises/dopeTask/main/scrip
 - [Integration guide](https://github.com/DDD-Enterprises/dopeTask/blob/main/docs/23_INTEGRATION_GUIDE.md)
 - [Upgrade guide](https://github.com/DDD-Enterprises/dopeTask/blob/main/docs/24_UPGRADE_GUIDE.md)
 - [Consumer install](https://github.com/DDD-Enterprises/dopeTask/blob/main/docs/25_CONSUMER_INSTALL.md)
+- [Supervisor prompts](https://github.com/DDD-Enterprises/dopeTask/blob/main/docs/26_SUPERVISOR_PROMPTS.md)
 
 ### Beginner onboarding
 
 - [Welcome](https://github.com/DDD-Enterprises/dopeTask/blob/main/docs/beginner/00_WELCOME.md)
+- [How dopeTask works](https://github.com/DDD-Enterprises/dopeTask/blob/main/docs/beginner/00A_HOW_DOPETASK_WORKS.md)
 - [Concepts](https://github.com/DDD-Enterprises/dopeTask/blob/main/docs/beginner/01_CONCEPTS.md)
 - [Installation](https://github.com/DDD-Enterprises/dopeTask/blob/main/docs/beginner/02_INSTALLATION.md)
 - [Web LLM setup](https://github.com/DDD-Enterprises/dopeTask/blob/main/docs/beginner/03_WEB_LLM_SETUP.md)

--- a/docs/00_OVERVIEW.md
+++ b/docs/00_OVERVIEW.md
@@ -35,6 +35,7 @@ Given the same packet, declared inputs, and dopeTask version, output artifacts a
 - `23_INTEGRATION_GUIDE.md`
 - `24_UPGRADE_GUIDE.md`
 - `25_CONSUMER_INSTALL.md`
+- `26_SUPERVISOR_PROMPTS.md`
 
 ### Supporting reference docs
 
@@ -46,6 +47,7 @@ Given the same packet, declared inputs, and dopeTask version, output artifacts a
 ### Beginner onboarding
 
 - `beginner/00_WELCOME.md`
+- `beginner/00A_HOW_DOPETASK_WORKS.md`
 - `beginner/01_CONCEPTS.md`
 - `beginner/02_INSTALLATION.md`
 - `beginner/03_WEB_LLM_SETUP.md`

--- a/docs/01_SETUP.md
+++ b/docs/01_SETUP.md
@@ -49,3 +49,29 @@ And checking the version:
 ```bash
 dopetask --version
 ```
+
+## Supervisor prompt setup
+
+The easiest way to set up a supervisor prompt is to use the built-in `ops` commands instead of copying a static markdown file by hand.
+
+Initialize the prompt profile and export a ChatGPT prompt:
+
+```bash
+dopetask ops init --platform chatgpt --model gpt-5.4
+```
+
+This writes the generated prompt to:
+
+```text
+ops/EXPORTED_OPERATOR_PROMPT.md
+```
+
+For workspace-aware tools such as Claude Code, Codex CLI, Gemini CLI, or Copilot CLI, apply the prompt directly into the repo instruction files:
+
+```bash
+dopetask ops apply
+```
+
+Use `dopetask ops doctor --no-export` to confirm the canonical target is current.
+
+For the full prompt-generation and installation matrix, see `26_SUPERVISOR_PROMPTS.md`.

--- a/docs/22_WORKFLOW_GUIDE.md
+++ b/docs/22_WORKFLOW_GUIDE.md
@@ -8,6 +8,8 @@ The series workflow is designed for high-trust, deterministic execution of multi
 
 Use this as the canonical workflow reference. If you are upgrading from older `tp exec` or `commit-sequence` habits, read `24_UPGRADE_GUIDE.md` alongside this guide. If you intentionally need the older manual path, see `20_WORKTREES_COMMIT_SEQUENCING.md`.
 
+Before you start a fresh supervisor session, generate or apply the current prompt using `26_SUPERVISOR_PROMPTS.md`.
+
 ## Lifecycle Stages
 
 ### 1. Planning (Task Packet Authoring)

--- a/docs/24_UPGRADE_GUIDE.md
+++ b/docs/24_UPGRADE_GUIDE.md
@@ -99,10 +99,11 @@ See `docs/integrations/dopetask/ADAPTER_SCHEMA.md` for the normalized integratio
 ## Recommended upgrade steps
 
 1. Upgrade the installed CLI to the current `dopeTask` release.
-2. Update supervisor prompts and local runbooks to use `tp series exec`, `status`, and `finalize`.
-3. Update any packet generators so they emit `depends_on`, `series`, and `commit`.
-4. Update any integrations that assumed a top-level `status` field in `SERIES_STATE.json`; the stable status summary now lives under `counts`, with packet details under `packets`.
-5. Keep legacy `commit-sequence` usage only where you intentionally need the old maintainer path.
+2. Regenerate supervisor prompts with `dopetask ops export` or reapply them with `dopetask ops apply`.
+3. Update supervisor prompts and local runbooks to use `tp series exec`, `status`, and `finalize`.
+4. Update any packet generators so they emit `depends_on`, `series`, and `commit`.
+5. Update any integrations that assumed a top-level `status` field in `SERIES_STATE.json`; the stable status summary now lives under `counts`, with packet details under `packets`.
+6. Keep legacy `commit-sequence` usage only where you intentionally need the old maintainer path.
 
 ## Documentation note
 

--- a/docs/26_SUPERVISOR_PROMPTS.md
+++ b/docs/26_SUPERVISOR_PROMPTS.md
@@ -1,0 +1,184 @@
+# Supervisor Prompt Generation and Installation
+
+This is the canonical guide for generating, exporting, and installing dopeTask supervisor prompts.
+
+Use this guide when you need to:
+
+- generate a fresh supervisor prompt for ChatGPT or Claude web
+- apply the generated prompt into workspace instruction files for Claude Code, Codex CLI, Gemini CLI, or Copilot CLI
+- update your repo after a dopeTask upgrade
+
+For the JSON Task Packet contract, see `13_TASK_PACKET_FORMAT.md`. For the execution flow after the prompt is installed, see `22_WORKFLOW_GUIDE.md`. For migration notes, see `24_UPGRADE_GUIDE.md`.
+
+## Recommended targets as of March 29, 2026
+
+### Web supervisors
+
+| Surface | Recommended target | Why |
+| --- | --- | --- |
+| ChatGPT | `gpt-5.4` | Current OpenAI docs present GPT-5.4 as the latest/default frontier model. |
+| Claude web | `claude-sonnet-4-6` for normal work, `claude-opus-4-6` for the hardest planning | Anthropic’s current models overview lists Sonnet 4.6 and Opus 4.6 as the latest Claude models. |
+
+### CLI and workspace-aware agents
+
+| Tool | Current version checked on March 29, 2026 | Notes |
+| --- | --- | --- |
+| Codex CLI | `0.117.0` | Checked from the `@openai/codex` npm registry and the latest GitHub release feed. |
+| Claude Code | `2.1.87` | Checked from the `@anthropic-ai/claude-code` npm registry package. |
+| Gemini CLI | `0.35.3` | Checked from the npm registry and latest GitHub release feed. |
+| Copilot CLI | `1.0.12` | Checked from the npm registry and latest GitHub release feed. |
+
+## Install or update the coding CLIs
+
+If you install these tools through npm, these are the current package names:
+
+```bash
+npm install -g @openai/codex@latest
+npm install -g @anthropic-ai/claude-code@latest
+npm install -g @google/gemini-cli@latest
+npm install -g @github/copilot@latest
+```
+
+Copilot CLI also has official Homebrew, WinGet, and install-script paths. See the GitHub Copilot CLI install docs if you prefer those package managers.
+
+## The easiest path
+
+If you are setting up a repository for the first time, run:
+
+```bash
+dopetask ops init --platform chatgpt --model gpt-5.4
+```
+
+This creates:
+
+- `ops/operator_profile.yaml`
+- `ops/templates/`
+- `ops/EXPORTED_OPERATOR_PROMPT.md`
+
+Then choose one of the two installation paths below.
+
+## Path A: Web chat products
+
+Use this for ChatGPT or Claude in the browser.
+
+### Generate a pasteable prompt
+
+For ChatGPT:
+
+```bash
+dopetask ops export --platform chatgpt --model gpt-5.4
+```
+
+For Claude web with Sonnet 4.6:
+
+```bash
+dopetask ops export --platform claude --model claude-sonnet-4-6
+```
+
+For Claude web with Opus 4.6:
+
+```bash
+dopetask ops export --platform claude --model claude-opus-4-6
+```
+
+The exported prompt is written to:
+
+```text
+ops/EXPORTED_OPERATOR_PROMPT.md
+```
+
+### Install it
+
+1. Open a new chat.
+2. Open `ops/EXPORTED_OPERATOR_PROMPT.md`.
+3. Copy the entire file.
+4. Paste it into the chat’s system/custom instructions surface, or use it as the first message if the product has no persistent system-instruction UI.
+
+### Verify the session
+
+Ask the model:
+
+```text
+What is your role in this repository?
+```
+
+The answer should stay supervisor-oriented:
+
+- author JSON Task Packets
+- do not implement code directly
+- delegate execution through `dopetask tp series exec`
+
+## Path B: Workspace-aware coding agents
+
+Use this for tools that read repo instruction files automatically, such as Claude Code, Codex CLI, Gemini CLI, Copilot CLI, Cursor, and Vibe.
+
+### Preview the generated block
+
+```bash
+dopetask ops preview
+```
+
+### Apply the generated prompt into the repo
+
+If your repo already uses `AGENTS.md`, `CLAUDE.md`, or `.claude/CLAUDE.md`, dopeTask will pick the canonical target automatically:
+
+```bash
+dopetask ops apply
+```
+
+If you want to force a specific target file:
+
+```bash
+dopetask ops apply --target AGENTS.md --platform codex --model gpt-5.4
+dopetask ops apply --target CLAUDE.md --platform claude-code --model claude-sonnet-4-6
+dopetask ops apply --target AGENTS.md --platform gemini --model gemini-cli-0.35.3
+dopetask ops apply --target AGENTS.md --platform copilot --model copilot-cli-1.0.12
+```
+
+### Verify the applied prompt
+
+Run:
+
+```bash
+dopetask ops doctor --no-export
+```
+
+You want the canonical target to report `BLOCK_OK`. If it reports `BLOCK_STALE`, rerun `dopetask ops apply`.
+
+### Tool-specific files now supported in this repo
+
+- `AGENTS.md` for cross-tool supervisor doctrine
+- `CLAUDE.md` plus `.claude/rules/` and `.claude/skills/` for Claude Code
+- `.github/copilot-instructions.md` plus `.github/agents/` for Copilot
+- `.cursor/rules/` for Cursor
+- `.vibe/prompts/` and `.vibe/agents/` for Vibe
+
+## Practical defaults
+
+Use these defaults unless you have a repo-specific reason not to:
+
+- ChatGPT: `gpt-5.4`
+- Claude web: `claude-sonnet-4-6`
+- Claude Code: `claude-sonnet-4-6`
+- Codex CLI: `gpt-5.4`
+- Gemini CLI: keep the dopeTask supervisor prompt in `AGENTS.md`, let Gemini CLI stay on its own current binary version
+- Copilot CLI: keep the dopeTask supervisor prompt in `AGENTS.md`, let Copilot CLI stay on its own current binary version
+
+## When to regenerate prompts
+
+Regenerate or reapply the prompt when:
+
+- you upgrade dopeTask
+- you change the target platform or model
+- `dopetask ops doctor` reports `BLOCK_STALE`
+- you changed `ops/templates/` or `ops/operator_profile.yaml`
+
+## Fallback: manual source prompt
+
+If you cannot use `dopetask ops export` for some reason, the fallback source prompt remains:
+
+```text
+docs/llm/SUPERVISOR_SYSTEM_PROMPT.md
+```
+
+That file is the manual baseline. The exported prompt is preferred because it includes your repo metadata, current platform, current model, and the generated operator header.

--- a/docs/beginner/00A_HOW_DOPETASK_WORKS.md
+++ b/docs/beginner/00A_HOW_DOPETASK_WORKS.md
@@ -1,0 +1,234 @@
+# How dopeTask works
+
+This page is the beginner-friendly explanation of what dopeTask is doing for you and why it exists.
+
+If you want the short version:
+
+dopeTask is a task orchestration system for AI-assisted software development.
+
+In plain English:
+
+It tells AI agents exactly what to do, in what order, under what rules, so they stop freelancing like chaotic interns.
+
+Instead of:
+
+- vague prompts
+- random code
+- hidden bugs
+- hallucinated files
+- late-night debugging
+
+You get:
+
+- structured tasks
+- deterministic execution
+- proof of what happened
+- repeatable results
+
+It is less "chatting with AI" and more "running a controlled operation."
+
+## What dopeTask does
+
+### 1. Breaks work into Task Packets
+
+Each Task Packet is a fully specified unit of work with clear steps, constraints, and outputs.
+
+Think:
+
+- `TP-001` add login system
+- `TP-002` add validation
+- `TP-003` add tests
+
+Except stricter and more machine-checkable.
+
+### 2. Controls AI agents
+
+Instead of letting an AI guess, skip steps, or invent structure, dopeTask forces:
+
+- step-by-step execution
+- rule compliance
+- validation before completion
+
+### 3. Produces proof bundles
+
+Every run generates evidence showing:
+
+- what changed
+- what ran
+- what passed
+- what failed
+
+So you do not have to guess whether the system actually did what you asked.
+
+### 4. Enables repeatable workflows
+
+You can:
+
+- rerun tasks
+- audit results
+- reproduce outputs
+
+That is something ordinary AI chat sessions do not do well on their own.
+
+## The real flow
+
+The core flow is:
+
+You -> Task Packet -> Supervisor -> Implementer -> Repo -> Proof
+
+### Supervisor
+
+The supervisor:
+
+- reads the task
+- enforces rules
+- decides the next packet or correction
+
+### Implementer
+
+The implementer is the coding agent, such as Codex, Gemini CLI, Claude Code, or Copilot CLI.
+
+It:
+
+- executes the packet
+- writes code
+- runs commands
+
+### Repo
+
+This is your actual project. dopeTask keeps changes isolated until they have passed the packet rules.
+
+### Proof Bundle
+
+The proof bundle is the evidence artifact that shows what happened and whether the execution validated successfully.
+
+## Practical usage
+
+### Step 1: Define the work clearly
+
+Do not just say:
+
+```text
+build auth system
+```
+
+A proper task needs structure:
+
+- goal
+- steps
+- constraints
+- outputs
+
+For example:
+
+- Goal: add email/password login
+- Steps: create auth service, add login endpoint, add validation, add tests
+- Constraints: no new dependencies, must pass existing tests
+- Output: updated files and passing validation
+
+The point is to remove ambiguity before the implementer starts.
+
+### Step 2: Run through a supervisor
+
+The supervisor turns your request into a JSON Task Packet and keeps the work bounded.
+
+Without that layer, an AI will often:
+
+- skip steps
+- invent APIs
+- rewrite unrelated parts of the repo
+
+### Step 3: Execute through dopeTask
+
+The implementer agent can be:
+
+- Codex
+- Gemini CLI
+- Claude Code
+- Copilot CLI
+
+dopeTask keeps the execution path deterministic and bounded.
+
+### Step 4: Review the proof
+
+You always review:
+
+- what changed
+- what passed
+- what failed
+
+Blind trust is not the workflow.
+
+## How this works with Git
+
+dopeTask uses isolation to keep your main branch safe.
+
+At a high level:
+
+- each Task Packet runs in its own worktree
+- changes are allowlist-checked
+- each packet creates one bounded commit
+- a packet series ends in one PR
+
+That keeps rollback simple and history readable.
+
+## Why this helps beginners
+
+AI systems have limited memory and weak discipline.
+
+Without structure, they:
+
+- forget instructions
+- contradict themselves
+- hallucinate missing context
+
+dopeTask compensates by using:
+
+- small contained tasks
+- explicit inputs
+- stateless execution boundaries
+- proof logs instead of vibes
+
+The result is that you stop depending on AI memory and start depending on system design.
+
+## Advantages
+
+- Reliability: less randomness, more control
+- Repeatability: the same input can produce the same output
+- Debuggability: you can inspect failures instead of guessing
+- Lower cognitive load: you think in tasks, not chaos
+- Cross-agent portability: the workflow is not tied to one model
+
+## Tradeoffs
+
+- More upfront structure
+- Slower than one-shot prompting
+- Some learning curve
+- Requires discipline
+
+The tradeoff is deliberate: more structure up front, less damage later.
+
+## The right mental model
+
+Stop thinking:
+
+```text
+AI is helping me code
+```
+
+Start thinking:
+
+```text
+I am orchestrating a system that uses AI as a tool
+```
+
+That shift is the difference between AI-assisted guessing and controlled engineering.
+
+When you want the exact current contract behind this beginner explanation, switch to the canonical docs:
+
+- `../00_OVERVIEW.md`
+- `../13_TASK_PACKET_FORMAT.md`
+- `../22_WORKFLOW_GUIDE.md`
+- `../26_SUPERVISOR_PROMPTS.md`
+
+👉 **[Next: Understanding Core Concepts](01_CONCEPTS.md)**

--- a/docs/beginner/00_WELCOME.md
+++ b/docs/beginner/00_WELCOME.md
@@ -38,6 +38,10 @@ dopeTask gives you **Deterministic Execution**. This means:
 
 Let's start by translating some developer jargon into plain English so you know exactly what dopeTask is doing under the hood.
 
+If you want the longer beginner-friendly explanation first, read:
+
+👉 **[How dopeTask works](00A_HOW_DOPETASK_WORKS.md)**
+
 This beginner guide is the onboarding path. Once you are comfortable with the basics, use the top-level docs as the canonical reference:
 
 - `../00_OVERVIEW.md`

--- a/docs/beginner/03_WEB_LLM_SETUP.md
+++ b/docs/beginner/03_WEB_LLM_SETUP.md
@@ -16,22 +16,36 @@ This page is the beginner onboarding version of the supervisor setup. For the ca
 
 ---
 
-## 1. The System Prompt
+## 1. Generate the Prompt First
 
-To transform your AI into a dopeTask Supervisor, you must give it a specific set of instructions at the very beginning of your chat session.
+Do not start by manually opening a markdown file.
 
-We have created a pre-written set of instructions for you.
+Instead, let dopeTask generate the current prompt for your tool:
 
-You can find it in the dopeTask repository here:
-`docs/llm/SUPERVISOR_SYSTEM_PROMPT.md`
+```bash
+dopetask ops init --platform chatgpt --model gpt-5.4
+```
+
+This creates a generated prompt file at:
+
+```text
+ops/EXPORTED_OPERATOR_PROMPT.md
+```
+
+If you want Claude web instead, export a Claude-specific prompt:
+
+```bash
+dopetask ops export --platform claude --model claude-sonnet-4-6
+```
 
 ## 2. Bootstrapping Your Session
 
-Whenever you start a new conversation with ChatGPT or Claude to work on your project, follow this exact process:
+Whenever you start a new conversation with ChatGPT or Claude to work on your project, follow this process:
 
 1. **Open a new chat window.**
-2. **Copy** the entire contents of the `SUPERVISOR_SYSTEM_PROMPT.md` file.
-3. **Paste** it into the first message of the chat and press send.
+2. **Open** `ops/EXPORTED_OPERATOR_PROMPT.md`.
+3. **Copy** the entire contents of that file.
+4. **Paste** it into the first message of the chat and press send.
 
 The AI should respond by confirming it understands its new role as a Supervisor and that it will only output Task Packet JSON files.
 
@@ -45,9 +59,27 @@ By pasting that prompt, you have given the AI strict boundaries:
 
 ## 4. Cursor and CLI Agents
 
-If you are using an IDE like **Cursor**, or a CLI agent like the **Gemini CLI**, you do not need to paste this prompt manually every time.
+If you are using a workspace-aware coding tool like **Claude Code**, **Codex CLI**, **Gemini CLI**, or **Copilot CLI**, you usually do not need to paste the prompt manually every time.
 
-These tools can read "workspace files." As long as you have the `AGENTS.md` and `CLAUDE.md` files (provided in the dopeTask repo) in the root folder of your project, they will automatically adopt the Supervisor role when working in that folder.
+Instead, apply the generated prompt into the repo instruction files:
+
+```bash
+dopetask ops apply
+```
+
+Then verify it:
+
+```bash
+dopetask ops doctor --no-export
+```
+
+For the full current model and CLI matrix, see `../26_SUPERVISOR_PROMPTS.md`.
+
+If you need the manual fallback source prompt, it still exists at:
+
+```text
+docs/llm/SUPERVISOR_SYSTEM_PROMPT.md
+```
 
 ---
 

--- a/docs/llm/DOPETASK_OPERATOR_SYSTEM.md
+++ b/docs/llm/DOPETASK_OPERATOR_SYSTEM.md
@@ -1,23 +1,23 @@
-<!-- DOPETASK:BEGIN operator_system v=1 platform=chatgpt model=gpt-5.2-thinking hash=cb46cbb836aaa9fc0d59f42c66348528dec271dabc019c1d65988913bbcb3c54 -->
+<!-- DOPETASK:BEGIN operator_system v=1 platform=chatgpt model=gpt-5.4 hash=0006c15aaea5ab01ac63f43b05557ee291b5d8090511608e7e9a84da0332dc50 -->
 # OPERATOR SYSTEM PROMPT
 
-# dopeTask Version: 0.5.0
+# dopeTask Version: 0.5.7
 
-# Git Commit: 8570642a5199134ecd5ed991b0953699b0e1bc5e
+# Git Commit: 97bc168810bae3b0add5cc6036cb320d582d2f26
 
 # Project: dopeTask
 
 # Platform: chatgpt
 
-# Model: gpt-5.2-thinking
+# Model: gpt-5.4
 
 # Repo Root: .
 
 # Timezone: America/Vancouver
 
-# dopeTask Pin: git_commit=8570642a5199134ecd5ed991b0953699b0e1bc5e
+# dopeTask Pin: git_commit=97bc168810bae3b0add5cc6036cb320d582d2f26
 
-# CLI Min Version: 0.5.0
+# CLI Min Version: 0.5.7
 
 
 
@@ -116,7 +116,12 @@ When forced to choose:
 - Explicit contracts over implicit behavior.
 
 # chatgpt Overlay
-Specifics for chatgpt
+
+Specifics for ChatGPT:
+
+- Prefer `gpt-5.4` as the default supervisor model.
+- Stay in supervisor mode: author JSON Task Packets and audit output, do not directly implement code.
+- When the user asks for execution, delegate to `dopetask tp series exec`, `status`, and `finalize`.
 
 ## Handoff contract
 - Follow all instructions provided in this prompt.

--- a/docs/llm/SUPERVISOR_SYSTEM_PROMPT.md
+++ b/docs/llm/SUPERVISOR_SYSTEM_PROMPT.md
@@ -1,5 +1,7 @@
 # ROLE: dopeTask SUPERVISOR (Web UI)
 
+Preferred generation path: use `dopetask ops export` to generate `ops/EXPORTED_OPERATOR_PROMPT.md` for the current platform and model. This file remains the canonical manual fallback source prompt.
+
 You are the **SUPERVISOR** agent for the `dopeTask` execution kernel. Your sole responsibility is to translate user requests into a declarative, machine-readable JSON **Task Packet**.
 
 ## MANDATE: NO DIRECT CODE

--- a/ops/OUT_OPERATOR_SYSTEM_PROMPT.md
+++ b/ops/OUT_OPERATOR_SYSTEM_PROMPT.md
@@ -1,22 +1,22 @@
 # OPERATOR SYSTEM PROMPT
 
-# dopeTask Version: 0.5.0
+# dopeTask Version: 0.5.7
 
-# Git Commit: 8570642a5199134ecd5ed991b0953699b0e1bc5e
+# Git Commit: 97bc168810bae3b0add5cc6036cb320d582d2f26
 
 # Project: dopeTask
 
 # Platform: chatgpt
 
-# Model: gpt-5.2-thinking
+# Model: gpt-5.4
 
 # Repo Root: .
 
 # Timezone: America/Vancouver
 
-# dopeTask Pin: git_commit=8570642a5199134ecd5ed991b0953699b0e1bc5e
+# dopeTask Pin: git_commit=97bc168810bae3b0add5cc6036cb320d582d2f26
 
-# CLI Min Version: 0.5.0
+# CLI Min Version: 0.5.7
 
 
 
@@ -115,7 +115,12 @@ When forced to choose:
 - Explicit contracts over implicit behavior.
 
 # chatgpt Overlay
-Specifics for chatgpt
+
+Specifics for ChatGPT:
+
+- Prefer `gpt-5.4` as the default supervisor model.
+- Stay in supervisor mode: author JSON Task Packets and audit output, do not directly implement code.
+- When the user asks for execution, delegate to `dopetask tp series exec`, `status`, and `finalize`.
 
 ## Handoff contract
 - Follow all instructions provided in this prompt.

--- a/ops/operator_profile.yaml
+++ b/ops/operator_profile.yaml
@@ -1,11 +1,11 @@
 platform:
-  model: gpt-5.2-thinking
+  model: gpt-5.4
   target: chatgpt
 project:
   name: dopeTask
   repo_root: .
   timezone: America/Vancouver
 dopetask:
-  cli_min_version: 0.5.0
+  cli_min_version: 0.5.7
   pin_type: git_commit
-  pin_value: 8570642a5199134ecd5ed991b0953699b0e1bc5e
+  pin_value: 97bc168810bae3b0add5cc6036cb320d582d2f26

--- a/ops/templates/overlays/chatgpt.md
+++ b/ops/templates/overlays/chatgpt.md
@@ -1,2 +1,7 @@
 # chatgpt Overlay
-Specifics for chatgpt
+
+Specifics for ChatGPT:
+
+- Prefer `gpt-5.4` as the default supervisor model.
+- Stay in supervisor mode: author JSON Task Packets and audit output, do not directly implement code.
+- When the user asks for execution, delegate to `dopetask tp series exec`, `status`, and `finalize`.

--- a/ops/templates/overlays/claude-code.md
+++ b/ops/templates/overlays/claude-code.md
@@ -1,0 +1,7 @@
+# claude-code Overlay
+
+Specifics for Claude Code:
+
+- Read repo instruction files first and preserve the dopeTask supervisor role.
+- Prefer `claude-sonnet-4-6` as the default model for repo-local supervisor work.
+- Emit Task Packet JSON and audit output, not direct implementation plans in prose.

--- a/ops/templates/overlays/claude.md
+++ b/ops/templates/overlays/claude.md
@@ -1,0 +1,7 @@
+# claude Overlay
+
+Specifics for Claude web:
+
+- Prefer `claude-sonnet-4-6` for normal supervisor work.
+- Use `claude-opus-4-6` when the planning surface is especially ambiguous or high risk.
+- Stay in supervisor mode: author JSON Task Packets, do not draft implementation code inline.

--- a/ops/templates/overlays/codex.md
+++ b/ops/templates/overlays/codex.md
@@ -1,0 +1,7 @@
+# codex Overlay
+
+Specifics for Codex:
+
+- Use `gpt-5.4` as the default supervisor model.
+- Respect repo instruction files and maintain supervisor-only behavior.
+- Emit JSON Task Packets or audit output; do not directly implement code from the supervisor channel.

--- a/ops/templates/overlays/copilot.md
+++ b/ops/templates/overlays/copilot.md
@@ -1,0 +1,7 @@
+# copilot Overlay
+
+Specifics for Copilot CLI:
+
+- Copilot CLI should honor the repo instruction block and stay in supervisor mode.
+- Prefer Task Packet JSON output and audit output over direct code generation in the supervisor path.
+- Keep execution delegated to `dopetask tp series exec`.

--- a/ops/templates/overlays/gemini.md
+++ b/ops/templates/overlays/gemini.md
@@ -1,0 +1,7 @@
+# gemini Overlay
+
+Specifics for Gemini CLI:
+
+- Gemini should remain in supervisor mode when running from a repo with dopeTask instructions.
+- Prefer generated repo instruction files over one-off pasted prompt fragments.
+- Require explicit validation in every generated Task Packet step.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dopetask"
-version = "0.5.6"
+version = "0.5.7"
 description = "Deterministic Task Packet execution kernel with proof bundles, worktree isolation, and series-based PR workflows."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/dopetask/__init__.py
+++ b/src/dopetask/__init__.py
@@ -1,3 +1,3 @@
 """dopeTask - Minimal Task Packet Lifecycle System."""
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"

--- a/src/dopetask/cli.py
+++ b/src/dopetask/cli.py
@@ -1177,7 +1177,7 @@ def init_cmd(
                 },
                 "platform": {
                     "target": platform,
-                    "model": "gpt-5.2-thinking",
+                    "model": "gpt-5.4",
                 },
             }
             with open(profile_path, "w") as f:

--- a/src/dopetask/ops/cli.py
+++ b/src/dopetask/ops/cli.py
@@ -76,7 +76,7 @@ def compile(
 @app.command()
 def init(
     platform: str = typer.Option("chatgpt", "--platform"),
-    model: str = typer.Option("gpt-5.2-thinking", "--model"),
+    model: str = typer.Option("gpt-5.4", "--model"),
     yes: bool = typer.Option(
         False,
         "--yes",

--- a/src/dopetask/router/availability.py
+++ b/src/dopetask/router/availability.py
@@ -26,7 +26,7 @@ AVAILABILITY_CONFIG_TEMPLATE: dict[str, Any] = {
             "cost_tier": "cheap",
             "context": "medium",
         },
-        "gpt-5.2": {
+        "gpt-5.4": {
             "strengths": ["correctness", "gates", "finalization"],
             "cost_tier": "medium",
             "context": "medium",
@@ -36,12 +36,17 @@ AVAILABILITY_CONFIG_TEMPLATE: dict[str, Any] = {
             "cost_tier": "high",
             "context": "large",
         },
+        "opus-4.6": {
+            "strengths": ["reasoning", "correctness", "code_edit"],
+            "cost_tier": "high",
+            "context": "large",
+        },
         "haiku-4.5": {
             "strengths": ["cheap", "docs", "summaries"],
             "cost_tier": "cheap",
             "context": "small",
         },
-        "sonnet-4.55": {
+        "sonnet-4.6": {
             "strengths": ["code_edit", "tests", "balanced"],
             "cost_tier": "medium",
             "context": "large",
@@ -69,7 +74,7 @@ AVAILABILITY_CONFIG_TEMPLATE: dict[str, Any] = {
         "require_explain": True,
         "stop_on_ambiguity": True,
         "max_cost_tier": "high",
-        "escalation_ladder": ["gpt-5.1-mini", "haiku-4.5", "sonnet-4.55", "gpt-5.3-codex"],
+        "escalation_ladder": ["gpt-5.1-mini", "haiku-4.5", "sonnet-4.6", "gpt-5.3-codex"],
         "max_escalations": 2,
         "min_total_score": 50,
     },

--- a/src/dopetask/router/scoring.py
+++ b/src/dopetask/router/scoring.py
@@ -112,7 +112,7 @@ def _score_model_fit(
             score += 16
             reasons.append("cheap_model_preferred")
     elif step == "run-task":
-        if model_name == "sonnet-4.55":
+        if model_name == "sonnet-4.6":
             score += 20
             reasons.append("preferred_code_edit_model")
         if wide_edit_surface and model_name == "gpt-5.3-codex":
@@ -125,10 +125,10 @@ def _score_model_fit(
         if model_name == "gpt-5.1-mini":
             score += 14
             reasons.append("cheap_evidence_model")
-        if complex_parsing and model_name in {"sonnet-4.55", "gpt-5.2"}:
+        if complex_parsing and model_name in {"sonnet-4.6", "gpt-5.4", "opus-4.6"}:
             score += 12
             reasons.append("complex_parsing")
-    elif step in {"gate-allowlist", "commit-run", "finish"} and model_name == "gpt-5.2":
+    elif step in {"gate-allowlist", "commit-run", "finish"} and model_name in {"gpt-5.4", "opus-4.6"}:
         score += 22
         reasons.append("correctness_pressure")
 

--- a/tests/unit/dopetask/test_orchestrate_v0_invariants.py
+++ b/tests/unit/dopetask/test_orchestrate_v0_invariants.py
@@ -186,7 +186,7 @@ def test_orchestrate_executes_only_selected_runner(monkeypatch, tmp_path: Path) 
 
 def test_refusal_route_plan_preserves_ladder_and_step_order(tmp_path: Path) -> None:
     repo = create_dopetask_repo(tmp_path / "repo")
-    custom_ladder = ["sonnet-4.55", "gpt-5.3-codex", "haiku-4.5"]
+    custom_ladder = ["sonnet-4.6", "gpt-5.3-codex", "haiku-4.5"]
     write_availability(
         repo,
         policy_overrides={"min_total_score": 999, "escalation_ladder": custom_ladder},

--- a/tests/unit/dopetask/test_route_plan_refusal_artifacts.py
+++ b/tests/unit/dopetask/test_route_plan_refusal_artifacts.py
@@ -16,7 +16,7 @@ from tests.unit.dopetask.route_test_utils import (
     write_packet,
 )
 
-DEFAULT_ESCALATION_LADDER = ["gpt-5.1-mini", "haiku-4.5", "sonnet-4.55", "gpt-5.3-codex"]
+DEFAULT_ESCALATION_LADDER = ["gpt-5.1-mini", "haiku-4.5", "sonnet-4.6", "gpt-5.3-codex"]
 
 
 def test_route_plan_refusal_writes_expected_artifacts(tmp_path: Path) -> None:
@@ -60,7 +60,7 @@ def test_route_plan_refusal_writes_expected_artifacts(tmp_path: Path) -> None:
 def test_escalation_ladder_order_respects_declaration(tmp_path: Path) -> None:
     repo = create_dopetask_repo(tmp_path / "ladder")
     packet = write_packet(repo)
-    custom_ladder = ["sonnet-4.55", "gpt-5.3-codex", "haiku-4.5"]
+    custom_ladder = ["sonnet-4.6", "gpt-5.3-codex", "haiku-4.5"]
     write_availability(repo, policy_overrides={"escalation_ladder": custom_ladder, "min_total_score": 10})
 
     runner = CliRunner()
@@ -173,7 +173,7 @@ def test_route_handoff_reports_step_order_and_packet(tmp_path: Path) -> None:
     contents = (repo / "out" / "dopetask_route" / "HANDOFF.md").read_text(encoding="utf-8")
     assert f"- packet_path: {packet}" in contents
     assert contents.index("## Step: alpha") < contents.index("## Step: beta")
-    assert "Model: sonnet-4.55" in contents
+    assert "Model: sonnet-4.6" in contents
 
 
 def test_route_explain_is_reproducible(tmp_path: Path) -> None:

--- a/tests/unit/dopetask/test_route_router_v1_invariants.py
+++ b/tests/unit/dopetask/test_route_router_v1_invariants.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import typing
@@ -36,11 +37,16 @@ def _write_packet(repo_root: Path, text: str = "# Packet\n") -> Path:
 
 
 def _run(repo_root: Path, args: list[str], expect: typing.Optional[int] = None) -> CompletedProcess:
+    project_root = Path(__file__).resolve().parents[3]
+    src_path = str(project_root / "src")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = src_path if not env.get("PYTHONPATH") else f"{src_path}{os.pathsep}{env['PYTHONPATH']}"
     result = subprocess.run(
         [sys.executable, "-m", "dopetask", *args],
         cwd=repo_root,
         text=True,
         capture_output=True,
+        env=env,
     )
     if expect is not None:
         assert result.returncode == expect, result.stdout + result.stderr
@@ -128,7 +134,7 @@ def test_route_plan_preserves_declared_ladder_order(repo: Path) -> None:
     text = availability_path.read_text()
     ladder_section = "escalation_ladder"
     assert ladder_section in text
-    new_ladder = ["sonnet-4.55", "gpt-5.3-codex", "haiku-4.5"]
+    new_ladder = ["sonnet-4.6", "gpt-5.3-codex", "haiku-4.5"]
     lines = text.splitlines()
     start = next(i for i, line in enumerate(lines) if ladder_section in line) + 1
     end = start


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary
- integrate the downloaded supervisor prompt pack into the repo's existing supervisor/config surfaces without replacing stronger repo-specific doctrine
- add current multi-surface prompt/install docs for ChatGPT, Claude, Copilot, Cursor, and Vibe, plus a beginner-oriented explainer
- update routing/model defaults to the current documented ladder and prepare the 0.5.7 release surface

## What changed
- merged pack doctrine into existing root instruction files and copilot instructions
- added new tool surfaces for `.github/agents`, `.cursor`, `.claude/rules`, `.claude/skills`, and `.vibe`
- added `docs/26_SUPERVISOR_PROMPTS.md` and `docs/beginner/00A_HOW_DOPETASK_WORKS.md`
- refreshed operator overlays, generated prompt output, router model availability/scoring, and release metadata for `0.5.7`
- aligned route-model tests with the current model ladder

## Validation
- `ruff check src/dopetask`
- `PYTHONPATH=src python -m dopetask.cli ops export --help`
- `PYTHONPATH=src python -m dopetask.cli ops apply --help`
- `PYTHONPATH=src python -m dopetask.cli --version`
- `python -m build && python -m twine check dist/*`
- `pytest -q --no-cov tests/unit/dopetask/test_route_router_v1_invariants.py tests/unit/dopetask/test_route_plan_refusal_artifacts.py tests/unit/dopetask/test_orchestrate_v0_invariants.py tests/unit/dopetask/test_router_plan_determinism.py tests/unit/dopetask/test_router_refusal.py tests/unit/dopetask/test_router_handoff.py tests/ops/test_ops.py`
- `bash scripts/dopetask_release_local.sh`

## Notes
- left the downloaded `dopetask_supervisor_pack.zip` untracked and out of the release
- preserved repo-specific supervisor rules instead of replacing them with generic pack text
