### PR TITLE
fix: restore main CI compatibility

### DIFF
--- a/src/dopetask/cli.py
+++ b/src/dopetask/cli.py
@@ -1172,7 +1172,7 @@ def _run_subprocess(
     *,
     cwd: Path,
     check: bool = True,
-    input_text: str | None = None,
+    input_text: typing.Optional[str] = None,
 ) -> subprocess.CompletedProcess[str]:
     completed = subprocess.run(
         argv,
@@ -1188,7 +1188,7 @@ def _run_subprocess(
     return completed
 
 
-def _install_command_for_tool(tool: str) -> list[str] | None:
+def _install_command_for_tool(tool: str) -> typing.Optional[list[str]]:
     if shutil.which("brew"):
         return ["brew", "install", tool]
     if shutil.which("apt-get"):
@@ -1353,7 +1353,7 @@ def _ensure_main_upstream(*, cwd: Path) -> list[str]:
     return actions
 
 
-def _parse_github_owner_repo(remote_url: str) -> tuple[str, str] | None:
+def _parse_github_owner_repo(remote_url: str) -> typing.Optional[tuple[str, str]]:
     ssh_match = re.match(r"^git@github\.com:(?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$", remote_url)
     if ssh_match:
         return ssh_match.group("owner"), ssh_match.group("repo")
@@ -1597,7 +1597,7 @@ def init_cmd(
     except RuntimeError:
         console.print("[bold red]Error:[/bold red] dopetask init requires an existing git repository.")
         console.print("Run `dopetask setup-git` first.")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     if not _git_init_state(repo_root_path)["is_git_repo"]:
         console.print("[bold red]Error:[/bold red] dopetask init requires an existing git repository.")
         console.print("Run `dopetask setup-git` first.")
@@ -4503,7 +4503,7 @@ def execute_cmd(
             repo=repo_root,
         )
         typer.echo(f"Imported/Updated: {import_result.tp_id}")
-        
+
         result = exec_series_packet(
             tp_file=import_result.packet_path,
             agent=agent,

--- a/src/dopetask/ops/tp_series/logic.py
+++ b/src/dopetask/ops/tp_series/logic.py
@@ -356,11 +356,14 @@ def _clipboard_install_hint(backend: str) -> str:
 
 
 def _auto_clipboard_backends() -> list[str]:
-    if sys.platform == "darwin":
+    platform_name: str = sys.platform
+    if platform_name == "darwin":
         return ["pbpaste"]
-    if sys.platform.startswith("linux"):
+    if platform_name.startswith("linux"):
         return ["wl-paste", "xclip", "xsel"]
-    raise RuntimeError(f"series import failed: unsupported platform for clipboard auto mode: {sys.platform}")
+    raise RuntimeError(
+        f"series import failed: unsupported platform for clipboard auto mode: {platform_name}"
+    )
 
 
 def _read_clipboard(*, backend: str) -> str:


### PR DESCRIPTION
## Summary
- restore Python 3.9-compatible typing syntax in the setup-git helpers
- raise `typer.Exit` with explicit exception chaining suppression for Ruff B904
- avoid mypy host-platform narrowing in clipboard backend auto-detection

## Validation
- `uv run --extra dev ruff check src/dopetask`
- `uv run --extra dev mypy src/dopetask`
- `uv run --extra dev pytest`
- `uv run dopetask doctor --timestamp-mode deterministic`
- `uv build`
- `bash scripts/check_build_determinism.sh`
- smoke install built wheel and run `dopetask doctor --timestamp-mode deterministic`