### PR TITLE
[codex] publish strict repo-aware task packet schema pack

### DIFF
--- a/docs/01_SETUP.md
+++ b/docs/01_SETUP.md
@@ -89,3 +89,15 @@ dopetask ops apply
 Use `dopetask ops doctor --no-export` to confirm the canonical target is current.
 
 For the full prompt-generation and installation matrix, see `26_SUPERVISOR_PROMPTS.md`.
+
+## Strict packet bootstrap
+
+If this repository should reject wrong-repo execution, bootstrap the repo-local instruction files and the strict packet policy at the same time:
+
+```bash
+dopetask project shell init
+dopetask ops init --platform chatgpt --model gpt-5.4
+dopetask ops apply
+```
+
+Then make sure new work uses the strict repo-aware Task Packet contract with `repo_binding`, `execution`, `commit.verify`, and `pr` when the work is repo-bound. PAL metadata stays optional for non-Gemini packets and is required and enabled for Gemini. The portable schema pack lives in `dopetask_schemas/task_packet.strict.schema.json`.

--- a/docs/10_ARCHITECTURE.md
+++ b/docs/10_ARCHITECTURE.md
@@ -48,6 +48,8 @@ The route/orchestrate plane remains active as a deterministic architecture surfa
 It plans one path, refuses with evidence, and supports runner-or-handoff outcomes.
 That plane is real, but it is not the only current execution story.
 
+All mutating planes now perform repo identity preflight before worktree creation, commit staging, or PR mutation. Packets that declare `repo_binding.require_identity_match = true` must only run in the repo whose canonical identity matches the binding.
+
 No side doors.
 No background threads.
 No secret tunnels.

--- a/docs/13_TASK_PACKET_FORMAT.md
+++ b/docs/13_TASK_PACKET_FORMAT.md
@@ -18,6 +18,25 @@ Runtime schema authority for Task Packets is `dopetask_schemas/task_packet.schem
 Runtime validation uses packaged schemas through `src/dopetask/utils/schema_registry.py` and `src/dopetask/schemas/validator.py`, not the docs tree.
 If you reference `docs/schemas/task_packet.schema.json`, treat it as a documentation mirror rather than the runtime validation source.
 
+Strict repo-aware packets may also include:
+
+- `repo_binding`
+- `execution`
+- `pr`
+
+These fields are optional in the generic runtime schema so older packets remain valid. When present, `repo_binding.require_identity_match` is the explicit fail-closed signal that the packet must only run inside the bound repository.
+
+The strict repo-aware policy schema is published separately at `dopetask_schemas/task_packet.strict.schema.json`. Use it when a repo wants the stricter contract surface:
+
+- required top-level fields: `project`, `target`, `invariants`, `repo_binding`, `series`, `execution`, `commit`, `pr`, `steps`
+- `commit.verify` must be non-empty
+- `execution.branch` belongs under `execution`, not `commit`
+- branch naming should remain deterministic, typically `series/<series.id>/<tp.id>`
+- `pr.base` should match `series.base_branch`
+- `pr.title` should include the series id when the packet participates in a series
+- `repo_binding.require_identity_match = true` means wrong-repo execution must fail closed
+- PAL metadata is allowed for all agents, but Gemini packets must include `pal_chain` with `enabled = true`
+
 ## Core execution fields
 
 - `project`: optional project name, defaults to `dopetask`
@@ -39,6 +58,11 @@ Optional step fields:
 
 `validation` must be non-empty. If you cannot verify a step with a shell command, the step is underspecified.
 
+Execution metadata, when present, belongs under `execution` rather than under `commit`:
+
+- `execution.agent` selects the agent profile
+- `execution.branch` carries the execution branch name when the packet wants to declare one explicitly
+
 ## Series fields
 
 New supervisor-driven work should include:
@@ -59,6 +83,8 @@ These fields define both packet readiness and git ancestry:
 - root packets use `series.parent_tp_id = null`
 - if `series.parent_tp_id` is set, it must also appear in `depends_on`
 - multi-branch fan-in happens in an explicit integration packet, not through implicit merging
+
+Mutating entrypoints now perform repo identity preflight before worktree or git changes. If a packet carries `repo_binding.require_identity_match = true`, the packet must run only in the repo that matches the binding.
 
 ## Runtime flow
 

--- a/docs/22_WORKFLOW_GUIDE.md
+++ b/docs/22_WORKFLOW_GUIDE.md
@@ -11,14 +11,16 @@ The series workflow is designed for high-trust, deterministic execution of multi
 Use this as the canonical and default operator workflow reference. If you are upgrading from older `tp exec` or `commit-sequence` habits, read `24_UPGRADE_GUIDE.md` alongside this guide. If you intentionally need the older manual path, see `20_WORKTREES_COMMIT_SEQUENCING.md`.
 
 Before you start a fresh supervisor session, generate or apply the current prompt using `26_SUPERVISOR_PROMPTS.md`.
+If the repo is bound for identity-checked work, default to the strict repo-aware packet contract and keep `execution.branch` execution-scoped rather than under `commit`.
 
 ## Lifecycle Stages
 
 ### 1. Planning (Task Packet Authoring)
 The Supervisor (AI or human) decomposes a high-level objective into atomic Task Packets.
-- **Key Metadata**: `series.id`, `depends_on`, `commit.allowlist`.
+- **Key Metadata**: `series.id`, `depends_on`, `commit.allowlist`, `repo_binding`, `execution`.
 - **Validation**: Every packet MUST have empirical verification commands.
 - **Packet handoff**: Save the JSON Task Packet to a file before execution, then run `dopetask tp series exec path/to/packet.json --agent gemini`.
+If a packet declares `repo_binding.require_identity_match = true`, the kernel refuses to mutate anything unless the active repo identity matches that binding.
 
 ### 2. Execution (`tp series exec`)
 Invoke the kernel to execute a specific packet:
@@ -36,6 +38,7 @@ Prerequisite: the repository must have an initial commit on `main`. `origin/main
 6. **Cleanup**: Deterministically removes the worktree.
 
 Use `--model` when you need to override the route-derived model for the selected agent. Precedence is explicit override first, route-derived model second, agent default last.
+If the packet includes `execution.branch`, that branch name is treated as execution-scoped metadata and is used by the series executor when present.
 
 ### 3. Monitoring (`tp series status`)
 Track the progress of a series and its dependency graph:

--- a/docs/23_INTEGRATION_GUIDE.md
+++ b/docs/23_INTEGRATION_GUIDE.md
@@ -40,13 +40,16 @@ jobs:
 The current low-level JSON TP executor is a separate specialist surface.
 Its runtime-supported execution surface now includes both `gemini` and `codex`.
 It is still a different plane from the default `tp series` workflow and from route/orchestrate runners.
+Strict repo-aware packets can adopt `dopetask_schemas/task_packet.strict.schema.json` when a repo wants mandatory `repo_binding`, `execution`, `commit.verify`, and Gemini PAL rules.
 
 To add another agent profile:
 
 1. **Implement the executor**: add an executor under `src/dopetask_adapters/<agent>/` that can run a compiled JSON TP and return the raw proof path.
 2. **Register the agent slug**: update `src/dopetask/ops/tp_exec/engine.py` so `execute_task_packet()` recognizes the new `--agent` value.
-3. **Keep the packet contract stable**: supervisors still emit JSON packets matching `docs/schemas/task_packet.schema.json`.
+3. **Keep the packet contract stable**: supervisors still emit JSON packets matching `dopetask_schemas/task_packet.schema.json`. Strict repo-aware packets may add `repo_binding`, `execution`, and `pr` metadata, but the packaged generic schema remains the runtime authority. Use the strict policy schema only when the repo explicitly wants the stricter contract.
 4. **Use the series workflow as the entrypoint**: new work should still run through `dopetask tp series exec ... --agent <agent> [--model <model>]`.
+
+Mutating entrypoints refuse wrong-repo execution before worktree or PR mutation. If a packet declares `repo_binding.require_identity_match = true`, the active repo must match the binding before `tp exec`, `tp series exec`, `tp series finalize`, or `tp git` PR/merge operations proceed.
 
 Route/orchestrate surfaces remain separate from both `tp series` and low-level `tp exec`.
 They provide route planning and runner-based execution behavior, not the default integration path for new work.

--- a/docs/24_UPGRADE_GUIDE.md
+++ b/docs/24_UPGRADE_GUIDE.md
@@ -68,6 +68,10 @@ Older packets or prompts that only covered steps are underspecified for the defa
 - `commit.message`
 - `commit.allowlist`
 - `commit.verify`
+- `repo_binding` and `execution` when the work should fail closed on repo identity mismatch
+- `pr` when the series is expected to finalize into a PR
+
+If you are upgrading a repo that wants the stricter policy pack, install or publish `dopetask_schemas/task_packet.strict.schema.json` alongside the generic runtime schema and update prompt/bootstrap files so they explain the stricter contract.
 
 See `docs/13_TASK_PACKET_FORMAT.md` for the current packet contract.
 
@@ -102,10 +106,11 @@ See `docs/integrations/dopetask/ADAPTER_SCHEMA.md` for the normalized integratio
 
 1. Upgrade the installed CLI to the current `dopeTask` release.
 2. Regenerate supervisor prompts with `dopetask ops export` or reapply them with `dopetask ops apply`.
-3. Update supervisor prompts and local runbooks to use `tp series exec`, `status`, and `finalize`.
-4. Update any packet generators so they emit `depends_on`, `series`, and `commit`.
-5. Update any integrations that assumed a top-level `status` field in `SERIES_STATE.json`; the stable status summary now lives under `counts`, with packet details under `packets`.
-6. Keep legacy `commit-sequence` usage only where you intentionally need the old maintainer path.
+3. If the repository uses identity-checked packets, re-run `dopetask project shell init` and `dopetask ops init` so the repo instruction files and exported prompt mention the strict packet contract.
+4. Update supervisor prompts and local runbooks to use `tp series exec`, `status`, and `finalize`.
+5. Update any packet generators so they emit `depends_on`, `series`, `commit`, `repo_binding`, `execution`, and `pr` where appropriate.
+6. Update any integrations that assumed a top-level `status` field in `SERIES_STATE.json`; the stable status summary now lives under `counts`, with packet details under `packets`.
+7. Keep legacy `commit-sequence` usage only where you intentionally need the old maintainer path.
 
 ## Documentation note
 

--- a/docs/25_CONSUMER_INSTALL.md
+++ b/docs/25_CONSUMER_INSTALL.md
@@ -29,6 +29,16 @@ dopetask doctor --timestamp-mode deterministic
 
 If the repository already uses `.venv` or the legacy `.dopetask_venv`, the launcher will reuse those environments.
 
+## Strict packet pack
+
+If the downstream repository wants the strict repo-aware contract, add the policy schema pack and update its bootstrap prompts after installing dopeTask:
+
+- `dopetask_schemas/task_packet.strict.schema.json`
+- strict packet examples for repo-bound work
+- repo instruction text that tells supervisors to emit `repo_binding`, `execution`, `commit.verify`, `pr`, and Gemini PAL metadata when applicable
+
+For a fresh downstream repository, run `dopetask project shell init`, then `dopetask ops init`, then `dopetask ops apply` so the installed prompt and repo instruction files explain the strict contract.
+
 ## Pinning and upgrades
 
 You can pin the install through `.dopetask-pin` and upgrade later with:

--- a/docs/26_SUPERVISOR_PROMPTS.md
+++ b/docs/26_SUPERVISOR_PROMPTS.md
@@ -175,6 +175,40 @@ Regenerate or reapply the prompt when:
 - `dopetask ops doctor` reports `BLOCK_STALE`
 - you changed `ops/templates/` or `ops/operator_profile.yaml`
 
+## JSON Packet Contract Notes
+
+When authoring JSON Task Packets for repo-bound work, include `repo_binding` and `execution` metadata when you need fail-closed identity checks or an explicit execution branch.
+Keep `commit` focused on commit behavior only. Do not move branch metadata into `commit`.
+
+## Strict Packet Policy
+
+Use the strict repo-aware Task Packet contract when a repository wants policy enforcement rather than the generic runtime minimum.
+
+Required strict fields:
+
+- `id`
+- `project`
+- `target`
+- `invariants`
+- `repo_binding`
+- `series`
+- `execution`
+- `commit`
+- `pr`
+- `steps`
+
+Required strict behaviors:
+
+- `commit.verify` must be non-empty
+- `execution.branch` must stay under `execution`
+- `execution.branch` should be deterministic, typically `series/<series.id>/<tp.id>`
+- `pr.base` should match `series.base_branch`
+- `pr.title` should include the series id when the packet is part of a series
+- `repo_binding.require_identity_match = true` must fail closed on repo mismatch
+- PAL metadata is allowed for all agents, but Gemini packets must carry enabled PAL chaining
+
+Use `dopetask_schemas/task_packet.schema.json` as the backward-compatible runtime schema and `dopetask_schemas/task_packet.strict.schema.json` as the policy schema for disciplined repos.
+
 ## Fallback: manual source prompt
 
 If you cannot use `dopetask ops export` for some reason, the fallback source prompt remains:

--- a/docs/beginner/02_INSTALLATION.md
+++ b/docs/beginner/02_INSTALLATION.md
@@ -27,6 +27,8 @@ dopetask --version
 ```
 If it prints a version number (like `0.3.0`), you are ready to go!
 
+If your repository wants the stricter repo-aware packet rules, the next setup step is `dopetask project shell init` followed by `dopetask ops init` and `dopetask ops apply`. Those commands write the repo-local instruction files that explain `repo_binding`, `execution`, `commit.verify`, `pr`, and PAL metadata rules for Gemini.
+
 ---
 
 ## 2. Set Up Your Project Folder

--- a/docs/beginner/03_WEB_LLM_SETUP.md
+++ b/docs/beginner/03_WEB_LLM_SETUP.md
@@ -56,6 +56,8 @@ By pasting that prompt, you have given the AI strict boundaries:
 *   **"Only output a blueprint (Task Packet) formatted as JSON."**
 *   **"Every step in your blueprint must include automated validation."**
 *   **"New work must use `depends_on`, `series`, and `commit` metadata so dopeTask can run each TP in its own worktree and finish the series as one PR."**
+*   If the work is repo-bound, include `repo_binding`, `execution`, `commit.verify`, and `pr`; use the strict schema pack for identity-checked repos.
+*   If the packet target is Gemini, add `pal_chain` and keep it enabled so the PAL metadata is explicit.
 
 ## 4. Cursor and CLI Agents
 

--- a/dopetask_schemas/task_packet.strict.schema.json
+++ b/dopetask_schemas/task_packet.strict.schema.json
@@ -1,46 +1,47 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "dopeTask TaskPacket",
-  "description": "A declarative plan for the dopeTask execution kernel. It defines a sequence of atomic steps to accomplish a development task without agent drift.",
+  "title": "dopeTask TaskPacket - strict repo policy",
+  "description": "Strict Task Packet contract for repo-bound, series-driven execution with mandatory repo identity binding, explicit execution metadata, verification evidence, and Gemini-required PAL chaining.",
   "type": "object",
   "properties": {
     "id": {
-      "description": "A unique identifier for this task packet (e.g., 'TP-CRM-001-setup').",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "project": {
-      "description": "The name of the project this task belongs to.",
       "type": "string",
-      "default": "dopetask"
+      "minLength": 1
     },
     "target": {
-      "description": "A high-level description of the ultimate goal of this Task Packet.",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "invariants": {
-      "description": "A list of conditions that must remain true after every step (e.g., 'No existing tests fail').",
       "type": "array",
+      "minItems": 1,
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "depends_on": {
-      "description": "Optional series-level packet dependencies that must complete before this packet may execute.",
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
-      "uniqueItems": true
+      "default": []
     },
     "repo_binding": {
-      "description": "Optional repo identity binding for stricter mutating workflows.",
       "type": "object",
       "properties": {
         "project_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "repo_marker": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "origin_hint": {
           "type": "string"
@@ -57,14 +58,15 @@
       "additionalProperties": false
     },
     "series": {
-      "description": "Optional series metadata for DAG-aware packet execution.",
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "base_branch": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "parent_tp_id": {
           "type": [
@@ -85,7 +87,6 @@
       "additionalProperties": false
     },
     "execution": {
-      "description": "Optional execution-scoped metadata for the target run.",
       "type": "object",
       "properties": {
         "agent": {
@@ -98,53 +99,61 @@
           ]
         },
         "branch": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         }
       },
       "required": [
-        "agent"
+        "agent",
+        "branch"
       ],
       "additionalProperties": false
     },
     "commit": {
-      "description": "Optional commit metadata used by the series executor.",
       "type": "object",
       "properties": {
         "message": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "allowlist": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         },
         "verify": {
           "type": "array",
+          "minItems": 1,
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         }
       },
       "required": [
         "message",
-        "allowlist"
+        "allowlist",
+        "verify"
       ],
       "additionalProperties": false
     },
     "pr": {
-      "description": "Optional PR metadata for series finalization and reuse.",
       "type": "object",
       "properties": {
         "title": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "body": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "base": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         }
       },
       "required": [
@@ -154,55 +163,75 @@
       ],
       "additionalProperties": false
     },
+    "pal_chain": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "required": [
+        "enabled",
+        "steps"
+      ],
+      "additionalProperties": false
+    },
     "steps": {
-      "description": "The ordered sequence of implementation steps.",
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "object",
         "properties": {
           "id": {
-            "description": "A unique ID for this step within the packet (e.g., 'step_1').",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "task": {
-            "description": "A detailed description of the implementation work for this specific step.",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "requirements": {
-            "description": "Specific constraints or rules for this step's implementation.",
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           "commands": {
-            "description": "A list of shell commands to execute during this step.",
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           "expected_files": {
-            "description": "A list of files that are expected to be created or modified by this step.",
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           "validation": {
-            "description": "CRITICAL: A list of shell commands used to verify the success of this step. MUST NOT BE EMPTY for Gemini agents.",
             "type": "array",
             "minItems": 1,
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           "context_files": {
-            "description": "A list of existing file paths that the implementer needs as context for this step.",
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         },
@@ -213,34 +242,18 @@
         ],
         "additionalProperties": false
       }
-    },
-    "supersedes": {
-      "description": "Optional list of Task Packet IDs that this packet supersedes.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "uniqueItems": true
-    },
-    "pal_chain": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean"
-        },
-        "steps": {
-          "type": "array"
-        }
-      },
-      "required": [
-        "enabled",
-        "steps"
-      ]
     }
   },
   "required": [
     "id",
+    "project",
     "target",
+    "invariants",
+    "repo_binding",
+    "series",
+    "execution",
+    "commit",
+    "pr",
     "steps"
   ],
   "allOf": [

--- a/ops/OUT_OPERATOR_SYSTEM_PROMPT.md
+++ b/ops/OUT_OPERATOR_SYSTEM_PROMPT.md
@@ -64,6 +64,17 @@ If a conflict is detected:
 - Determinism over cleverness.
 - Every change must be auditable.
 
+## Strict Task Packet Policy
+
+- New repo-bound work should default to the strict repo-aware Task Packet contract.
+- Required strict packet fields: `id`, `project`, `target`, `invariants`, `repo_binding`, `series`, `execution`, `commit`, `pr`, `steps`.
+- `commit.verify` must be non-empty.
+- `execution.branch` is execution-scoped metadata and should be deterministic, typically `series/<series.id>/<tp.id>`.
+- `pr.base` should match `series.base_branch`, and `pr.title` should include the series id.
+- `repo_binding.require_identity_match = true` means wrong-repo execution must fail closed.
+- PAL metadata is allowed for all agents, but Gemini packets must include `pal_chain` with `enabled = true`.
+- Treat `dopetask_schemas/task_packet.strict.schema.json` as the strict policy schema and `dopetask_schemas/task_packet.schema.json` as the backward-compatible runtime schema.
+
 ## Determinism Contract
 
 - Same inputs -> same outputs.

--- a/ops/templates/base_supervisor.md
+++ b/ops/templates/base_supervisor.md
@@ -42,6 +42,17 @@ If a conflict is detected:
 - Determinism over cleverness.
 - Every change must be auditable.
 
+## Strict Task Packet Policy
+
+- New repo-bound work should default to the strict repo-aware Task Packet contract.
+- Required strict packet fields: `id`, `project`, `target`, `invariants`, `repo_binding`, `series`, `execution`, `commit`, `pr`, `steps`.
+- `commit.verify` must be non-empty.
+- `execution.branch` is execution-scoped metadata and should be deterministic, typically `series/<series.id>/<tp.id>`.
+- `pr.base` should match `series.base_branch`, and `pr.title` should include the series id.
+- `repo_binding.require_identity_match = true` means wrong-repo execution must fail closed.
+- PAL metadata is allowed for all agents, but Gemini packets must include `pal_chain` with `enabled = true`.
+- Treat `dopetask_schemas/task_packet.strict.schema.json` as the strict policy schema and `dopetask_schemas/task_packet.schema.json` as the backward-compatible runtime schema.
+
 ## Determinism Contract
 
 - Same inputs -> same outputs.

--- a/src/dopetask/assets/templates/AGENTS.template.md
+++ b/src/dopetask/assets/templates/AGENTS.template.md
@@ -1,5 +1,9 @@
 # AGENTS Instructions
 
+Repo-aware work should use the strict repo-aware Task Packet contract by default.
+When a packet binds to this repository, it must carry `repo_binding`, `execution`, `commit.verify`, `pr`, and a non-empty `steps.validation` plan.
+PAL metadata is allowed for all agents, and Gemini packets must keep `pal_chain.enabled = true`.
+
 <!-- DOPETASK:BEGIN -->
 (disabled)
 <!-- DOPETASK:END -->

--- a/src/dopetask/assets/templates/CLAUDE.template.md
+++ b/src/dopetask/assets/templates/CLAUDE.template.md
@@ -1,5 +1,9 @@
 # CLAUDE Instructions
 
+Repo-aware work should use the strict repo-aware Task Packet contract by default.
+When a packet binds to this repository, it must carry `repo_binding`, `execution`, `commit.verify`, `pr`, and a non-empty `steps.validation` plan.
+PAL metadata is allowed for all agents, and Gemini packets must keep `pal_chain.enabled = true`.
+
 <!-- DOPETASK:BEGIN -->
 (disabled)
 <!-- DOPETASK:END -->

--- a/src/dopetask/assets/templates/CODEX.template.md
+++ b/src/dopetask/assets/templates/CODEX.template.md
@@ -1,5 +1,9 @@
 # CODEX Instructions
 
+Repo-aware work should use the strict repo-aware Task Packet contract by default.
+When a packet binds to this repository, it must carry `repo_binding`, `execution`, `commit.verify`, `pr`, and a non-empty `steps.validation` plan.
+PAL metadata is allowed for all agents, and Gemini packets must keep `pal_chain.enabled = true`.
+
 <!-- DOPETASK:BEGIN -->
 (disabled)
 <!-- DOPETASK:END -->

--- a/src/dopetask/assets/templates/PROJECT_INSTRUCTIONS.template.md
+++ b/src/dopetask/assets/templates/PROJECT_INSTRUCTIONS.template.md
@@ -1,5 +1,9 @@
 # Project Instructions
 
+New work in this repository should default to the strict repo-aware Task Packet contract.
+When a packet is repo-bound, it must include `repo_binding`, `execution`, `commit.verify`, `pr`, and `steps` metadata and should fail closed on repo mismatch.
+PAL metadata is allowed for all agents, and Gemini packets must keep `pal_chain.enabled = true`.
+
 <!-- DOPETASK:BEGIN -->
 (disabled)
 <!-- DOPETASK:END -->

--- a/src/dopetask/cli.py
+++ b/src/dopetask/cli.py
@@ -1172,7 +1172,7 @@ def _run_subprocess(
     *,
     cwd: Path,
     check: bool = True,
-    input_text: str | None = None,
+    input_text: typing.Optional[str] = None,
 ) -> subprocess.CompletedProcess[str]:
     completed = subprocess.run(
         argv,
@@ -1188,7 +1188,7 @@ def _run_subprocess(
     return completed
 
 
-def _install_command_for_tool(tool: str) -> list[str] | None:
+def _install_command_for_tool(tool: str) -> typing.Optional[list[str]]:
     if shutil.which("brew"):
         return ["brew", "install", tool]
     if shutil.which("apt-get"):
@@ -1353,7 +1353,7 @@ def _ensure_main_upstream(*, cwd: Path) -> list[str]:
     return actions
 
 
-def _parse_github_owner_repo(remote_url: str) -> tuple[str, str] | None:
+def _parse_github_owner_repo(remote_url: str) -> typing.Optional[tuple[str, str]]:
     ssh_match = re.match(r"^git@github\.com:(?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$", remote_url)
     if ssh_match:
         return ssh_match.group("owner"), ssh_match.group("repo")

--- a/src/dopetask/core/compilers/gemini.py
+++ b/src/dopetask/core/compilers/gemini.py
@@ -30,12 +30,15 @@ class GeminiCompiler(BaseCompiler):
         """
         if not tp.steps:
             raise ValueError("TaskPacket must have at least one step for Gemini profile.")
-        if not getattr(tp, "pal_chain", None) or not tp.pal_chain.enabled:
+        pal_chain = tp.pal_chain
+        if not pal_chain or not pal_chain.enabled:
             raise ValueError("Fail-Closed: Gemini execution requires a valid and enabled pal_chain block.")
-        if not tp.pal_chain.steps:
+        if not pal_chain.steps:
             raise ValueError("Fail-Closed: Gemini execution requires non-empty pal_chain.steps.")
-        if len(tp.pal_chain.steps) < len(tp.steps):
-            raise ValueError(f"Fail-Closed: Each execution step must have a corresponding PAL step mapping (found {len(tp.pal_chain.steps)} PAL steps for {len(tp.steps)} TP steps).")
+        if len(pal_chain.steps) < len(tp.steps):
+            raise ValueError(
+                f"Fail-Closed: Each execution step must have a corresponding PAL step mapping (found {len(pal_chain.steps)} PAL steps for {len(tp.steps)} TP steps)."
+            )
 
         compiled_steps: list[dict[str, Any]] = []
 
@@ -61,5 +64,5 @@ class GeminiCompiler(BaseCompiler):
             "id": tp.id,
             "project": tp.project,
             "target": tp.target,
-            "steps": compiled_steps
+            "steps": compiled_steps,
         }

--- a/src/dopetask/core/schema.py
+++ b/src/dopetask/core/schema.py
@@ -131,7 +131,7 @@ class TaskPacket:
                     enabled=bool(raw_pal.get("enabled", False)),
                     steps=raw_pal.get("steps", []),
                 )
-            
+
             raw_commit = data.get("commit")
             commit = None
             if raw_commit is not None:
@@ -141,7 +141,13 @@ class TaskPacket:
                     verify=raw_commit.get("verify", []),
                 )
 
-            if data.get('id') and data.get('id') in data.get("supersedes", []): raise ValueError(f"Packet {data.get('id')} cannot supersede itself".replace("data.get(\"id\")", "data.get(\047id\047)"))
+            if data.get("id") and data.get("id") in data.get("supersedes", []):
+                raise ValueError(
+                    f"Packet {data.get('id')} cannot supersede itself".replace(
+                        'data.get("id")',
+                        "data.get('id')",
+                    )
+                )
             return cls(
                 id=data["id"],
                 target=data.get("target", "Target"),
@@ -176,10 +182,10 @@ class TaskPacket:
                     "commands": step.commands,
                     "expected_files": step.expected_files,
                     "validation": step.validation,
-                    "context_files": step.context_files
+                    "context_files": step.context_files,
                 }
                 for step in self.steps
-            ]
+            ],
         }
         if self.repo_binding is not None:
             repo_binding_payload: dict[str, Any] = {
@@ -204,7 +210,8 @@ class TaskPacket:
             if self.execution.branch is not None:
                 execution_payload["branch"] = self.execution.branch
             payload["execution"] = execution_payload
-        if self.supersedes: payload["supersedes"] = self.supersedes
+        if self.supersedes:
+            payload["supersedes"] = self.supersedes
         if self.pal_chain is not None:
             payload["pal_chain"] = {"enabled": self.pal_chain.enabled, "steps": self.pal_chain.steps}
         if self.commit is not None:

--- a/src/dopetask/core/schema.py
+++ b/src/dopetask/core/schema.py
@@ -5,6 +5,24 @@ from typing import Any, Optional
 
 
 @dataclass
+class TPRepoBinding:
+    """Repo-binding metadata for strict packet execution."""
+
+    project_id: str
+    repo_marker: str
+    require_identity_match: bool = False
+    origin_hint: Optional[str] = None
+
+
+@dataclass
+class TPExecution:
+    """Execution-scoped metadata for a packet run."""
+
+    agent: str
+    branch: Optional[str] = None
+
+
+@dataclass
 class TPStep:
     """A single execution step in a Task Packet."""
     id: str
@@ -51,8 +69,11 @@ class TaskPacket:
     steps: list[TPStep] = field(default_factory=list)
     invariants: list[str] = field(default_factory=list)
     depends_on: list[str] = field(default_factory=list)
+    repo_binding: Optional[TPRepoBinding] = None
     series: Optional[TPSeries] = None
+    execution: Optional[TPExecution] = None
     commit: Optional[TPCommit] = None
+    pr: Optional[dict[str, Any]] = None
     supersedes: list[str] = field(default_factory=list)
     pal_chain: Optional[TPPalChain] = None
 
@@ -85,6 +106,24 @@ class TaskPacket:
                     final_packet=bool(raw_series.get("final_packet", False)),
                 )
 
+            raw_binding = data.get("repo_binding")
+            repo_binding = None
+            if raw_binding is not None:
+                repo_binding = TPRepoBinding(
+                    project_id=raw_binding["project_id"],
+                    repo_marker=raw_binding["repo_marker"],
+                    origin_hint=raw_binding.get("origin_hint"),
+                    require_identity_match=bool(raw_binding.get("require_identity_match", False)),
+                )
+
+            raw_execution = data.get("execution")
+            execution = None
+            if raw_execution is not None:
+                execution = TPExecution(
+                    agent=raw_execution["agent"],
+                    branch=raw_execution.get("branch"),
+                )
+
             raw_pal = data.get("pal_chain")
             pal_chain = None
             if raw_pal is not None:
@@ -110,8 +149,11 @@ class TaskPacket:
                 steps=steps,
                 invariants=data.get("invariants", []),
                 depends_on=data.get("depends_on", []),
+                repo_binding=repo_binding,
                 series=series,
+                execution=execution,
                 commit=commit,
+                pr=data.get("pr"),
                 supersedes=data.get("supersedes", []),
                 pal_chain=pal_chain,
             )
@@ -139,6 +181,15 @@ class TaskPacket:
                 for step in self.steps
             ]
         }
+        if self.repo_binding is not None:
+            repo_binding_payload: dict[str, Any] = {
+                "project_id": self.repo_binding.project_id,
+                "repo_marker": self.repo_binding.repo_marker,
+                "require_identity_match": self.repo_binding.require_identity_match,
+            }
+            if self.repo_binding.origin_hint is not None:
+                repo_binding_payload["origin_hint"] = self.repo_binding.origin_hint
+            payload["repo_binding"] = repo_binding_payload
         if self.series is not None:
             payload["series"] = {
                 "id": self.series.id,
@@ -146,6 +197,13 @@ class TaskPacket:
                 "parent_tp_id": self.series.parent_tp_id,
                 "final_packet": self.series.final_packet,
             }
+        if self.execution is not None:
+            execution_payload: dict[str, Any] = {
+                "agent": self.execution.agent,
+            }
+            if self.execution.branch is not None:
+                execution_payload["branch"] = self.execution.branch
+            payload["execution"] = execution_payload
         if self.supersedes: payload["supersedes"] = self.supersedes
         if self.pal_chain is not None:
             payload["pal_chain"] = {"enabled": self.pal_chain.enabled, "steps": self.pal_chain.steps}
@@ -155,4 +213,6 @@ class TaskPacket:
                 "allowlist": self.commit.allowlist,
                 "verify": self.commit.verify,
             }
+        if self.pr is not None:
+            payload["pr"] = self.pr
         return payload

--- a/src/dopetask/guard/identity.py
+++ b/src/dopetask/guard/identity.py
@@ -199,7 +199,7 @@ def assert_repo_branch_identity(repo_identity: RepoIdentity, branch_name: str) -
 def assert_repo_binding(
     repo_identity: RepoIdentity,
     repo_root: Path,
-    repo_binding: typing.Optional["TPRepoBinding"],
+    repo_binding: typing.Optional[TPRepoBinding],
 ) -> None:
     """Hard-fail when a packet repo binding does not match the active repo."""
     if repo_binding is None:
@@ -221,8 +221,6 @@ def assert_repo_binding(
             f"ERROR: Task Packet repo_marker '{repo_binding.repo_marker}' does not exist in repo_root '{repo_root}'.\n"
             "Refusing to run."
         )
-
-
 
 def run_identity_origin_warning(
     repo_identity: RepoIdentity,

--- a/src/dopetask/guard/identity.py
+++ b/src/dopetask/guard/identity.py
@@ -16,6 +16,7 @@ from dopetask.obs.run_artifacts import (
 )
 
 if TYPE_CHECKING:
+    from dopetask.core.schema import TPRepoBinding
     from dopetask.pipeline.task_runner.types import ProjectIdentity
 
 
@@ -191,6 +192,33 @@ def assert_repo_branch_identity(repo_identity: RepoIdentity, branch_name: str) -
     if branch_project_id != repo_identity.project_id:
         raise RuntimeError(
             f"ERROR: Current branch project_id '{branch_project_id}' does not match repo project_id '{repo_identity.project_id}'.\n"
+            "Refusing to run."
+        )
+
+
+def assert_repo_binding(
+    repo_identity: RepoIdentity,
+    repo_root: Path,
+    repo_binding: typing.Optional["TPRepoBinding"],
+) -> None:
+    """Hard-fail when a packet repo binding does not match the active repo."""
+    if repo_binding is None:
+        return
+
+    binding_project_id = repo_binding.project_id.strip()
+    if not binding_project_id:
+        raise RuntimeError("ERROR: Task Packet repo_binding.project_id is empty.\nRefusing to run.")
+
+    if repo_binding.require_identity_match and binding_project_id != repo_identity.project_id:
+        raise RuntimeError(
+            f"ERROR: Task Packet repo_binding.project_id '{binding_project_id}' does not match repo project_id '{repo_identity.project_id}'.\n"
+            "Refusing to run. Use the correct repo or correct packet."
+        )
+
+    marker_path = (repo_root / repo_binding.repo_marker).resolve()
+    if not marker_path.exists():
+        raise RuntimeError(
+            f"ERROR: Task Packet repo_marker '{repo_binding.repo_marker}' does not exist in repo_root '{repo_root}'.\n"
             "Refusing to run."
         )
 

--- a/src/dopetask/obs/proof_aggregator.py
+++ b/src/dopetask/obs/proof_aggregator.py
@@ -154,7 +154,7 @@ class ProofAggregator:
                 digest = hashlib.sha256(str(path).encode("utf-8")).hexdigest()[:8]
                 entry_name = f"{path.stem}__{digest}{path.suffix}"
             while entry_name in used_names:
-                digest = hashlib.sha256(f"{path}:{entry_name}".encode("utf-8")).hexdigest()[:8]
+                digest = hashlib.sha256(f"{path}:{entry_name}".encode()).hexdigest()[:8]
                 entry_name = f"{path.stem}__{digest}{path.suffix}"
             used_names.add(entry_name)
             entries.append((path, entry_name))

--- a/src/dopetask/ops/cli.py
+++ b/src/dopetask/ops/cli.py
@@ -162,6 +162,17 @@ If a conflict is detected:
 - Determinism over cleverness.
 - Every change must be auditable.
 
+## Strict Task Packet Policy
+
+- New repo-bound work should default to the strict repo-aware Task Packet contract.
+- Required strict packet fields: `id`, `project`, `target`, `invariants`, `repo_binding`, `series`, `execution`, `commit`, `pr`, `steps`.
+- `commit.verify` must be non-empty.
+- `execution.branch` is execution-scoped metadata and should be deterministic, typically `series/<series.id>/<tp.id>`.
+- `pr.base` should match `series.base_branch`, and `pr.title` should include the series id.
+- `repo_binding.require_identity_match = true` means wrong-repo execution must fail closed.
+- PAL metadata is allowed for all agents, but Gemini packets must include `pal_chain` with `enabled = true`.
+- Treat `dopetask_schemas/task_packet.strict.schema.json` as the strict policy schema and `dopetask_schemas/task_packet.schema.json` as the backward-compatible runtime schema.
+
 ## Determinism Contract
 
 - Same inputs -> same outputs.

--- a/src/dopetask/ops/tp_exec/engine.py
+++ b/src/dopetask/ops/tp_exec/engine.py
@@ -12,7 +12,7 @@ from typing import Optional
 from dopetask.core.tp_parser import TPNormalizer, TPParser
 from dopetask.guard.identity import assert_repo_binding, assert_repo_identity, load_repo_identity
 from dopetask.obs.proof_aggregator import ProofAggregator
-from dopetask.pipeline.task_runner.executor import TaskExecutor
+from dopetask.pipeline.task_runner.executor import Adapter, TaskExecutor
 from dopetask_adapters.codex.executor import CodexExecutor
 from dopetask_adapters.gemini.executor import GeminiAdapter
 
@@ -63,6 +63,7 @@ def execute_task_packet(
             requested_model=model,
         )
 
+        adapter: Adapter
         if agent == "gemini":
             adapter = GeminiAdapter(
                 model=effective_model,

--- a/src/dopetask/ops/tp_exec/engine.py
+++ b/src/dopetask/ops/tp_exec/engine.py
@@ -10,8 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from dopetask.core.tp_parser import TPNormalizer, TPParser
-from dopetask.guard.identity import load_repo_identity
-from dopetask.guard.identity import assert_repo_binding, assert_repo_identity
+from dopetask.guard.identity import assert_repo_binding, assert_repo_identity, load_repo_identity
 from dopetask.obs.proof_aggregator import ProofAggregator
 from dopetask.pipeline.task_runner.executor import TaskExecutor
 from dopetask_adapters.codex.executor import CodexExecutor
@@ -81,12 +80,12 @@ def execute_task_packet(
 
         # Kernel-side TaskExecutor validates adapter output shape.
         kernel_executor = TaskExecutor(adapter)
-        
-        # Transitional Phase 1: Unpack the new ExecutionResult stream while 
+
+        # Transitional Phase 1: Unpack the new ExecutionResult stream while
         # still using the legacy_proof_path for backward compatibility.
         results, raw_proof_path_str = kernel_executor.execute(compiled_tp)
         raw_proof_path = Path(raw_proof_path_str).resolve()
-        
+
         aggregator = ProofAggregator(tp.id)
 
         with raw_proof_path.open(encoding="utf-8") as handle:

--- a/src/dopetask/ops/tp_exec/engine.py
+++ b/src/dopetask/ops/tp_exec/engine.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Optional
 
 from dopetask.core.tp_parser import TPNormalizer, TPParser
+from dopetask.guard.identity import load_repo_identity
+from dopetask.guard.identity import assert_repo_binding, assert_repo_identity
 from dopetask.obs.proof_aggregator import ProofAggregator
 from dopetask.pipeline.task_runner.executor import TaskExecutor
 from dopetask_adapters.codex.executor import CodexExecutor
@@ -44,9 +46,16 @@ def execute_task_packet(
     from dopetask.ops.tp_git.guards import resolve_repo_root
 
     repo_root = resolve_repo_root(working_dir or Path.cwd())
+    repo_identity = load_repo_identity(repo_root)
 
     with _pushd(working_dir):
         tp = TPParser.parse_file(resolved_tp_file)
+        assert_repo_identity(repo_root)
+        assert_repo_binding(repo_identity, repo_root, tp.repo_binding)
+        if tp.execution is not None and tp.execution.agent != agent:
+            raise RuntimeError(
+                f"Task Packet execution.agent '{tp.execution.agent}' does not match selected agent '{agent}'."
+            )
         compiled_tp = TPNormalizer.compile(tp, agent)
 
         effective_model, effective_model_source = _resolve_effective_model(

--- a/src/dopetask/ops/tp_git/git_worktree.py
+++ b/src/dopetask/ops/tp_git/git_worktree.py
@@ -6,10 +6,10 @@ import typing
 from dataclasses import dataclass
 from pathlib import Path
 
+from dopetask.guard.identity import assert_repo_identity
 from dopetask.ops.tp_git.exec import run_git
 from dopetask.ops.tp_git.guards import DoctorReport, resolve_repo_root, run_doctor
 from dopetask.ops.tp_git.naming import resolve_target
-from dopetask.guard.identity import assert_repo_identity
 
 
 @dataclass(frozen=True)

--- a/src/dopetask/ops/tp_git/git_worktree.py
+++ b/src/dopetask/ops/tp_git/git_worktree.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from dopetask.ops.tp_git.exec import run_git
 from dopetask.ops.tp_git.guards import DoctorReport, resolve_repo_root, run_doctor
 from dopetask.ops.tp_git.naming import resolve_target
+from dopetask.guard.identity import assert_repo_identity
 
 
 @dataclass(frozen=True)
@@ -116,6 +117,7 @@ def tp_status(*, tp_id: str, repo: typing.Optional[Path] = None) -> dict[str, st
 def sync_main(*, repo: typing.Optional[Path] = None) -> dict[str, str]:
     """Sync main branch with ff-only policy."""
     repo_root = resolve_repo_root(repo)
+    assert_repo_identity(repo_root)
     run_git(["checkout", "main"], repo_root=repo_root)
     fetch = run_git(["fetch", "--all", "--prune"], repo_root=repo_root)
     pull = run_git(["pull", "--ff-only"], repo_root=repo_root)
@@ -129,6 +131,7 @@ def sync_main(*, repo: typing.Optional[Path] = None) -> dict[str, str]:
 def cleanup_tp(*, tp_id: str, repo: typing.Optional[Path] = None) -> dict[str, str]:
     """Remove TP worktree after validating cleanliness."""
     repo_root = resolve_repo_root(repo)
+    assert_repo_identity(repo_root)
     worktree_path = (repo_root / ".worktrees" / tp_id).resolve()
     if not worktree_path.exists():
         raise RuntimeError(f"cleanup failed: worktree does not exist: {worktree_path}")

--- a/src/dopetask/ops/tp_git/github.py
+++ b/src/dopetask/ops/tp_git/github.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from dopetask.ops.tp_git.exec import run_command, run_git
+from dopetask.guard.identity import assert_repo_identity
 from dopetask.ops.tp_git.guards import resolve_repo_root
 from dopetask.ops.tp_git.naming import build_worktree_path
 
@@ -68,6 +69,7 @@ def pr_create(
 ) -> dict[str, Any]:
     """Push TP branch and open PR via gh."""
     repo_root = resolve_repo_root(repo)
+    assert_repo_identity(repo_root)
     _ensure_gh_auth(repo_root)
 
     worktree_path = _worktree_for_tp(repo_root, tp_id)
@@ -132,6 +134,7 @@ def merge_pr(
         raise RuntimeError(f"unsupported merge mode: {mode}")
 
     repo_root = resolve_repo_root(repo)
+    assert_repo_identity(repo_root)
     _ensure_gh_auth(repo_root)
     worktree_path = _worktree_for_tp(repo_root, tp_id)
 

--- a/src/dopetask/ops/tp_git/github.py
+++ b/src/dopetask/ops/tp_git/github.py
@@ -7,8 +7,8 @@ import typing
 from pathlib import Path
 from typing import Any
 
-from dopetask.ops.tp_git.exec import run_command, run_git
 from dopetask.guard.identity import assert_repo_identity
+from dopetask.ops.tp_git.exec import run_command, run_git
 from dopetask.ops.tp_git.guards import resolve_repo_root
 from dopetask.ops.tp_git.naming import build_worktree_path
 

--- a/src/dopetask/ops/tp_git/guards.py
+++ b/src/dopetask/ops/tp_git/guards.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from dopetask.ops.tp_git.exec import ExecError, ExecResult, run_git
+from dopetask.guard.identity import assert_repo_identity
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,7 @@ def run_doctor(
 ) -> DoctorReport:
     """Enforce clean-main+no-stash gate and sync remote refs."""
     repo_root = resolve_repo_root(repo)
+    assert_repo_identity(repo_root)
 
     branch = run_git(["rev-parse", "--abbrev-ref", "HEAD"], repo_root=repo_root).stdout.strip()
     if branch != "main":

--- a/src/dopetask/ops/tp_git/guards.py
+++ b/src/dopetask/ops/tp_git/guards.py
@@ -6,8 +6,8 @@ import typing
 from dataclasses import dataclass
 from pathlib import Path
 
-from dopetask.ops.tp_git.exec import ExecError, ExecResult, run_git
 from dopetask.guard.identity import assert_repo_identity
+from dopetask.ops.tp_git.exec import ExecError, ExecResult, run_git
 
 
 @dataclass(frozen=True)

--- a/src/dopetask/ops/tp_series/logic.py
+++ b/src/dopetask/ops/tp_series/logic.py
@@ -17,6 +17,7 @@ from typing import Any, Optional, cast
 
 from dopetask.core.schema import TaskPacket
 from dopetask.core.tp_parser import TPParser
+from dopetask.guard.identity import assert_repo_binding, assert_repo_identity, load_repo_identity
 from dopetask.ops.tp_exec.engine import execute_task_packet
 from dopetask.ops.tp_git.exec import run_command, run_git
 from dopetask.ops.tp_git.guards import resolve_repo_root
@@ -171,6 +172,7 @@ def _parse_status_paths(status_output: str) -> list[str]:
 
 def _run_series_doctor(*, repo_root: Path) -> None:
     """Fail closed on dirty main while allowing series-owned artifacts."""
+    assert_repo_identity(repo_root)
     branch_result = run_git(["symbolic-ref", "--quiet", "--short", "HEAD"], repo_root=repo_root, check=False)
     if branch_result.returncode != 0:
         raise RuntimeError(
@@ -280,6 +282,13 @@ def _copy_proof_artifacts(*, worktree_path: Path, run_dir: Path) -> Optional[Pat
             if item.name.endswith("_PROOF_BUNDLE.json"):
                 copied_bundle = destination.resolve()
     return copied_bundle
+
+
+def _packet_branch(tp: TaskPacket) -> str:
+    execution = getattr(tp, "execution", None)
+    if execution is not None and getattr(execution, "branch", None):
+        return str(execution.branch)
+    return build_tp_branch(tp.id, normalize_slug(tp.target or tp.id))
 
 
 def _ensure_series_packet(tp: TaskPacket) -> None:
@@ -405,6 +414,7 @@ def import_series_packet(
     By default, reads from the clipboard. If source_file is provided, reads from that file instead.
     """
     repo_root = resolve_repo_root(repo)
+    repo_identity = load_repo_identity(repo_root)
 
     if source_file is not None:
         payload = json.loads(source_file.read_text(encoding="utf-8"))
@@ -420,6 +430,8 @@ def import_series_packet(
 
     tp = TPParser.parse_dict(payload)
     _ensure_series_import_packet(tp)
+    assert_repo_identity(repo_root)
+    assert_repo_binding(repo_identity, repo_root, tp.repo_binding)
     _validate_series_import_state(repo_root=repo_root, tp=tp, overwrite=overwrite)
     assert tp.series is not None
 
@@ -438,10 +450,6 @@ def import_series_packet(
         validation="structural-ok",
         message=f"series packet imported: {tp.id}",
     )
-
-
-def _packet_branch(tp: TaskPacket) -> str:
-    return build_tp_branch(tp.id, normalize_slug(tp.target or tp.id))
 
 
 def _dependency_records(state: dict[str, Any], depends_on: list[str]) -> dict[str, dict[str, Any]]:
@@ -518,6 +526,7 @@ def cleanup_series_artifacts(
     *, repo_root: Path, series_id: str, packet_id: Optional[str] = None, force: bool = False
 ) -> list[str]:
     """Purge stale worktrees and branches for a series."""
+    assert_repo_identity(repo_root)
     series_dir = _series_dir(repo_root, series_id)
     state_path = _state_path(series_dir)
     if not state_path.exists():
@@ -608,11 +617,18 @@ def exec_series_packet(
 ) -> SeriesExecResult:
     """Execute a JSON Task Packet inside a series-aware git workflow."""
     repo_root = resolve_repo_root(repo)
+    repo_identity = load_repo_identity(repo_root)
     _run_series_doctor(repo_root=repo_root)
 
     packet_path = tp_file.resolve()
     tp = TPParser.parse_file(packet_path)
     _ensure_series_packet(tp)
+    assert_repo_identity(repo_root)
+    assert_repo_binding(repo_identity, repo_root, tp.repo_binding)
+    if tp.execution is not None and tp.execution.agent != agent:
+        raise RuntimeError(
+            f"series exec failed: packet execution.agent '{tp.execution.agent}' does not match selected agent '{agent}'"
+        )
     assert tp.series is not None
     assert tp.commit is not None
 

--- a/src/dopetask/pipeline/task_runner/executor.py
+++ b/src/dopetask/pipeline/task_runner/executor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import typing
 from typing import Any, Protocol
 
 from dopetask.pipeline.task_runner.types import ExecutionResult
@@ -26,15 +25,15 @@ class TaskExecutor:
 
         Returns:
             A tuple of (execution_results, legacy_proof_path).
-            The legacy_proof_path is retained for backward compatibility with 
+            The legacy_proof_path is retained for backward compatibility with
             Phase 1 aggregation logic.
         """
         results, legacy_proof_path = self.adapter.run_tp(tp)
-        
+
         # Kernel validation of adapter output
         if not isinstance(results, list):
             raise TypeError(f"Adapter results must be a list of ExecutionResult, got {type(results)}")
-            
+
         for result in results:
             if not isinstance(result, ExecutionResult):
                 raise TypeError(f"Invalid adapter output: expected ExecutionResult, got {type(result)}")

--- a/src/dopetask/pipeline/task_runner/types.py
+++ b/src/dopetask/pipeline/task_runner/types.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import typing
-from typing import TypedDict
 from dataclasses import dataclass, field
+from typing import TypedDict
 
 
 class NormalizedOutput(TypedDict):

--- a/src/dopetask/pipeline/task_runner/types.py
+++ b/src/dopetask/pipeline/task_runner/types.py
@@ -14,9 +14,7 @@ class NormalizedOutput(TypedDict):
     commands_run: list[str]
     validation_passed: bool
 
-class ExecutionMetrics(TypedDict, total=False):
-    tokens: int
-    duration_seconds: float
+ExecutionMetrics = dict[str, typing.Any]
 
 @dataclass
 class ProjectIdentity:
@@ -71,5 +69,4 @@ class ExecutionResult:
     normalized_output: NormalizedOutput
     metrics: ExecutionMetrics = field(default_factory=dict)
     error: typing.Optional[str] = None
-
 

--- a/src/dopetask_adapters/codex/executor.py
+++ b/src/dopetask_adapters/codex/executor.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
-from dopetask.pipeline.task_runner.types import ExecutionResult
-from dopetask_adapters.codex.proof_writer import ProofWriter
+from dopetask.pipeline.task_runner.types import ExecutionResult, NormalizedOutput
 from dopetask_adapters.codex.prompts import build_step_prompt
+from dopetask_adapters.codex.proof_writer import ProofWriter
 
 
 def _parse_status_paths(status_output: str) -> set[str]:
@@ -194,9 +194,9 @@ class CodexExecutor:
             result_dict = self._run_step(tp, step)
             raw_results.append(result_dict)
 
-            status = "succeeded" if result_dict.get("validation_passed") else "failed"
+            status: Literal["succeeded", "failed"] = "succeeded" if result_dict.get("validation_passed") else "failed"
             error = "\n".join(result_dict.get("errors", [])) if result_dict.get("errors") else None
-            normalized = {
+            normalized: NormalizedOutput = {
                 "files_created": result_dict.get("files_created", []),
                 "changed_files": result_dict.get("changed_files", []),
                 "commands_run": result_dict.get("commands_run", []),

--- a/src/dopetask_adapters/gemini/executor.py
+++ b/src/dopetask_adapters/gemini/executor.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Optional, Literal
+from typing import Any, Literal, Optional
 
-from dopetask.pipeline.task_runner.types import ExecutionResult
+from dopetask.pipeline.task_runner.types import ExecutionResult, NormalizedOutput
 
-from .step_runner import StepRunner
-from .proof_writer import ProofWriter
-from .validator import Validator
 from .prompts import GEMINI_PROMPTS
+from .proof_writer import ProofWriter
+from .step_runner import StepRunner
+from .validator import Validator
+
 
 class GeminiAdapter:
     """Gemini-specific execution adapter."""
@@ -30,12 +31,12 @@ class GeminiAdapter:
     def compile_system_prompts(self, tp: dict[str, Any]) -> tuple[str, str]:
         """Compiles TURN 1 and TURN 2 prompts for Gemini."""
         turn_1 = GEMINI_PROMPTS["TURN_1_SYSTEM_FRAME"]
-        
+
         # Extract files from all steps
         all_files = []
         for step in tp.get("steps", []):
             all_files.extend(step.get("expected_files", []))
-            
+
         turn_2 = GEMINI_PROMPTS["TURN_2_CONTEXT_LOAD"].format(
             project=tp.get("project", "dopetask"),
             target=tp.get("target", "Target"),
@@ -46,28 +47,28 @@ class GeminiAdapter:
     def run_tp(self, tp: dict[str, Any]) -> tuple[list[ExecutionResult], str]:
         """Execute a full Task Packet and return standardized results and proof path."""
         self.compile_system_prompts(tp)
-        
+
         # TODO: Send turn_1 and turn_2 to the LLM context to initialize the session.
-        
+
         raw_results = []
         execution_results: list[ExecutionResult] = []
 
         for step in tp["steps"]:
             result_dict = self.runner.run_step(step)
             raw_results.append(result_dict)
-            
+
             # Map raw step result to ExecutionResult contract
             status: Literal["succeeded", "failed"] = "succeeded" if result_dict.get("validation_passed") else "failed"
             error = "\n".join(result_dict.get("errors", [])) if result_dict.get("errors") else None
-            
+
             # Pack normalized fields without leaking provider internals
-            normalized = {
+            normalized: NormalizedOutput = {
                 "files_created": result_dict.get("files_created", []),
                 "commands_run": result_dict.get("commands_run", []),
                 "validation_passed": result_dict.get("validation_passed", False),
-                "changed_files": result_dict.get("changed_files", [])
+                "changed_files": result_dict.get("changed_files", []),
             }
-            
+
             exec_result = ExecutionResult(
                 step_id=result_dict["step_id"],
                 status=status,
@@ -93,5 +94,5 @@ class GeminiAdapter:
                 "effective_model_source": self.effective_model_source,
             },
         )
-        
+
         return execution_results, proof_path

--- a/src/dopetask_adapters/gemini/prompts.py
+++ b/src/dopetask_adapters/gemini/prompts.py
@@ -31,7 +31,7 @@ OUTPUT FORMAT (MANDATORY):
   "validation": true|false,
   "errors": []
 }""",
-    
+
     "TURN_2_CONTEXT_LOAD": """PROJECT: {project}
 TARGET: {target}
 
@@ -43,7 +43,7 @@ INVARIANTS:
 - fail closed
 - deterministic output
 - proof required""",
-    
+
     "TURN_3_STEP": """STEP ID: {step_id}
 
 TASK:
@@ -80,7 +80,7 @@ Return:
 1. files created
 2. code blocks per file
 3. verification steps""",
-    
+
     "TURN_2_TASK": """Implement {target} in:
 {target_dir}
 
@@ -111,7 +111,7 @@ TASK:
 
 OUTPUT:
 Only code.""",
-    
+
     "TURN_2_STEP": """TASK:
 {task}
 

--- a/src/dopetask_adapters/gemini/proof_writer.py
+++ b/src/dopetask_adapters/gemini/proof_writer.py
@@ -1,7 +1,8 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
+
 
 class ProofWriter:
     def write(
@@ -9,7 +10,7 @@ class ProofWriter:
         tp_id: str,
         steps: list[dict[str, Any]],
         *,
-        metadata: dict[str, Any] | None = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> str:
         bundle = {
             "tp_id": tp_id,
@@ -37,30 +38,30 @@ class ProofWriter:
                 step_id = step_res.get("step_id", "UNKNOWN")
                 f.write(f"STEP: {step_id}\n")
                 f.write("-" * 40 + "\n")
-                
-                output_log = step_res.get("output_log", [])
+                output_log = step_res.get("output_log") or []
                 for entry in output_log:
                     cmd_type = entry.get("type", "exec").upper()
                     f.write(f"[{cmd_type}] Command: {entry.get('command')}\n")
                     f.write(f"Return Code: {entry.get('returncode')}\n")
-                    
+
                     stdout = entry.get("stdout", "").strip()
                     if stdout:
                         f.write("STDOUT:\n")
                         f.write(stdout + "\n")
-                    
+
                     stderr = entry.get("stderr", "").strip()
                     if stderr:
                         f.write("STDERR:\n")
                         f.write(stderr + "\n")
                     f.write("\n")
-                
-                if step_res.get("errors"):
+
+                errors = step_res.get("errors") or []
+                if errors:
                     f.write("ERRORS:\n")
-                    for err in step_res.get("errors"):
+                    for err in errors:
                         f.write(f"- {err}\n")
                     f.write("\n")
-                
+
                 f.write(f"Status: {'VALIDATED' if step_res.get('validation_passed') else 'FAILED'}\n")
                 f.write("\n")
 

--- a/src/dopetask_adapters/gemini/schema.py
+++ b/src/dopetask_adapters/gemini/schema.py
@@ -1,13 +1,11 @@
-from typing import List
-
 class StepResult:
     def __init__(
         self,
         step_id: str,
-        files_created: List[str],
-        commands_run: List[str],
+        files_created: list[str],
+        commands_run: list[str],
         validation_passed: bool,
-        errors: List[str]
+        errors: list[str],
     ):
         self.step_id = step_id
         self.files_created = files_created
@@ -17,6 +15,6 @@ class StepResult:
 
 
 class TPProofBundle:
-    def __init__(self, tp_id: str, steps: List[StepResult]):
+    def __init__(self, tp_id: str, steps: list[StepResult]):
         self.tp_id = tp_id
         self.steps = steps

--- a/src/dopetask_adapters/gemini/step_runner.py
+++ b/src/dopetask_adapters/gemini/step_runner.py
@@ -1,12 +1,12 @@
-import json
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from .prompts import GEMINI_PROMPTS
 
+
 class StepRunner:
-    def __init__(self, model: str = None) -> None:
+    def __init__(self, model: Optional[str] = None) -> None:
         self.model = model
 
     def compile_step_prompt(self, step: dict[str, Any]) -> str:
@@ -39,7 +39,7 @@ class StepRunner:
             for cmd in step.get("commands", []):
                 result["commands_run"].append(cmd)
                 cp = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-                
+
                 # Capture output for trace
                 result["output_log"].append({
                     "command": cmd,
@@ -66,7 +66,7 @@ class StepRunner:
             val_passed = True
             for val_cmd in step.get("validation", []):
                 v_cp = subprocess.run(val_cmd, shell=True, capture_output=True, text=True)
-                
+
                 # Capture validation output for trace
                 result["output_log"].append({
                     "command": val_cmd,

--- a/tests/integration/test_codex_exec_integration.py
+++ b/tests/integration/test_codex_exec_integration.py
@@ -17,6 +17,12 @@ def _init_repo(path: Path) -> Path:
     subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True, capture_output=True, text=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True, capture_output=True, text=True)
+    (path / ".dopetaskroot").write_text("", encoding="utf-8")
+    (path / ".dopetask").mkdir(parents=True, exist_ok=True)
+    (path / ".dopetask" / "project.json").write_text(
+        json.dumps({"project_id": "dopetask.core"}, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
     return path
 
 

--- a/tests/ops/test_ops.py
+++ b/tests/ops/test_ops.py
@@ -89,8 +89,12 @@ def test_ops_init_exports_by_default(tmp_path, monkeypatch):
 
     export_file = tmp_path / "ops" / "EXPORTED_OPERATOR_PROMPT.md"
     assert export_file.exists()
+    exported = export_file.read_text()
+    assert "Strict Task Packet Policy" in exported
+    assert "task_packet.strict.schema.json" in exported
+    assert "pal_chain" in exported
 
-    first_hash = calculate_hash(export_file.read_text())
+    first_hash = calculate_hash(exported)
 
     # Run again - should be idempotent
     result = runner.invoke(app, ["init"])
@@ -168,6 +172,7 @@ def test_ops_export_write_on_change(tmp_path, monkeypatch):
 
     export_file = tmp_path / "ops" / "EXPORTED_OPERATOR_PROMPT.md"
     assert export_file.exists()
+    assert "Strict Task Packet Policy" in export_file.read_text()
 
     # Second export
     result = runner.invoke(app, ["export"])

--- a/tests/unit/dopetask/test_tp_exec_codex.py
+++ b/tests/unit/dopetask/test_tp_exec_codex.py
@@ -20,6 +20,12 @@ def _init_repo(path: Path) -> Path:
     subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True, capture_output=True, text=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True, capture_output=True, text=True)
+    (path / ".dopetaskroot").write_text("", encoding="utf-8")
+    (path / ".dopetask").mkdir(parents=True, exist_ok=True)
+    (path / ".dopetask" / "project.json").write_text(
+        json.dumps({"project_id": "dopetask.core"}, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
     return path
 
 
@@ -29,6 +35,9 @@ def _write_json_packet(
     expected_files: list[str],
     validation: list[str],
     commands: list[str] | None = None,
+    repo_binding: dict[str, object] | None = None,
+    execution: dict[str, object] | None = None,
+    pal_chain: dict[str, object] | None = None,
 ) -> Path:
     payload = {
         "id": "TP-CODEX-TEST",
@@ -46,8 +55,56 @@ def _write_json_packet(
             }
         ],
     }
+    if repo_binding is not None:
+        payload["repo_binding"] = repo_binding
+    if execution is not None:
+        payload["execution"] = execution
+    if pal_chain is not None:
+        payload["pal_chain"] = pal_chain
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return path
+
+
+def test_execute_task_packet_refuses_repo_binding_mismatch(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    packet = _write_json_packet(
+        repo / "packet.json",
+        expected_files=[],
+        validation=["true"],
+        repo_binding={
+            "project_id": "other.project",
+            "repo_marker": ".dopetaskroot",
+            "require_identity_match": True,
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="repo_binding.project_id 'other.project' does not match"):
+        execute_task_packet(packet, agent="codex", working_dir=repo)
+
+
+def test_execute_task_packet_refuses_agent_mismatch(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    packet = _write_json_packet(
+        repo / "packet.json",
+        expected_files=[],
+        validation=["true"],
+        execution={
+            "agent": "gemini",
+            "branch": "series/TP-CODEX-TEST",
+        },
+        repo_binding={
+            "project_id": "dopetask.core",
+            "repo_marker": ".dopetaskroot",
+            "require_identity_match": True,
+        },
+        pal_chain={
+            "enabled": True,
+            "steps": ["analysis"],
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="execution.agent 'gemini' does not match selected agent 'codex'"):
+        execute_task_packet(packet, agent="codex", working_dir=repo)
 
 
 def test_execute_task_packet_codex_creates_expected_files_and_bundle(monkeypatch, tmp_path: Path) -> None:

--- a/tests/unit/dopetask/test_tp_exec_truthfulness.py
+++ b/tests/unit/dopetask/test_tp_exec_truthfulness.py
@@ -14,6 +14,12 @@ def _init_repo(path: Path) -> Path:
     subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True, capture_output=True, text=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True, capture_output=True, text=True)
+    (path / ".dopetaskroot").write_text("", encoding="utf-8")
+    (path / ".dopetask").mkdir(parents=True, exist_ok=True)
+    (path / ".dopetask" / "project.json").write_text(
+        json.dumps({"project_id": "dopetask.core"}, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
     return path
 
 
@@ -25,6 +31,7 @@ def test_gemini_raw_proof_does_not_claim_missing_expected_files(tmp_path: Path) 
             {
                 "id": "TP-TRUTH",
                 "target": "truthful proof",
+                "pal_chain": {"enabled": True, "steps": ["analysis"]},
                 "steps": [
                     {
                         "id": "S1",

--- a/tests/unit/git/test_worktree.py
+++ b/tests/unit/git/test_worktree.py
@@ -35,7 +35,13 @@ def repo_with_origin(tmp_path: Path) -> Path:
     _git(repo, "config", "user.name", "Test User")
 
     (repo / "README.md").write_text("# test\n", encoding="utf-8")
-    _git(repo, "add", "README.md")
+    (repo / ".dopetaskroot").write_text("", encoding="utf-8")
+    (repo / ".dopetask").mkdir(parents=True, exist_ok=True)
+    (repo / ".dopetask" / "project.json").write_text(
+        json.dumps({"project_id": "dopetask.core"}, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "README.md", ".dopetaskroot", ".dopetask/project.json")
     _git(repo, "commit", "-m", "initial")
     _git(repo, "branch", "-M", "main")
     _git(repo, "remote", "add", "origin", str(remote))

--- a/tests/unit/project/test_init.py
+++ b/tests/unit/project/test_init.py
@@ -25,6 +25,9 @@ def test_init_creates_files_when_missing(tmp_path: Path) -> None:
 
     for filename in ("PROJECT_INSTRUCTIONS.md", "CLAUDE.md", "CODEX.md", "AGENTS.md"):
         text = (out_dir / filename).read_text(encoding="utf-8")
+        assert "strict repo-aware Task Packet contract" in text
+        assert "repo_binding" in text
+        assert "pal_chain.enabled = true" in text
         assert "<!-- DOPETASK:BEGIN -->" in text
         assert "<!-- DOPETASK:END -->" in text
         assert "<!-- CHATX:BEGIN -->" in text

--- a/tests/unit/test_schema_registry.py
+++ b/tests/unit/test_schema_registry.py
@@ -3,7 +3,13 @@ import pytest
 
 from dopetask.utils.schema_registry import SchemaRegistry
 
-REQUIRED = {"allowlist_diff", "promotion_token", "run_envelope", "run_summary"}
+REQUIRED = {
+    "allowlist_diff",
+    "promotion_token",
+    "run_envelope",
+    "run_summary",
+    "task_packet.strict",
+}
 
 
 def test_required_schemas_available():

--- a/tests/unit/tp_git/test_guards.py
+++ b/tests/unit/tp_git/test_guards.py
@@ -35,6 +35,7 @@ def test_doctor_passes_when_main_clean_no_stash(monkeypatch: pytest.MonkeyPatch)
         ("fetch", "--all", "--prune"): _result(["fetch", "--all", "--prune"], stdout=""),
         ("pull", "--ff-only"): _result(["pull", "--ff-only"], stdout="Already up to date.\n"),
     }
+    monkeypatch.setattr("dopetask.ops.tp_git.guards.assert_repo_identity", lambda repo_root: None)
     monkeypatch.setattr("dopetask.ops.tp_git.guards.run_git", _GitStub(outputs))
 
     report = run_doctor(repo=Path("/repo"))
@@ -47,6 +48,7 @@ def test_doctor_refuses_non_main(monkeypatch: pytest.MonkeyPatch) -> None:
         ("rev-parse", "--show-toplevel"): _result(["rev-parse", "--show-toplevel"], stdout="/repo\n"),
         ("rev-parse", "--abbrev-ref", "HEAD"): _result(["rev-parse", "--abbrev-ref", "HEAD"], stdout="feature\n"),
     }
+    monkeypatch.setattr("dopetask.ops.tp_git.guards.assert_repo_identity", lambda repo_root: None)
     monkeypatch.setattr("dopetask.ops.tp_git.guards.run_git", _GitStub(outputs))
 
     with pytest.raises(RuntimeError, match="expected branch main"):
@@ -59,6 +61,7 @@ def test_doctor_refuses_dirty(monkeypatch: pytest.MonkeyPatch) -> None:
         ("rev-parse", "--abbrev-ref", "HEAD"): _result(["rev-parse", "--abbrev-ref", "HEAD"], stdout="main\n"),
         ("status", "--porcelain"): _result(["status", "--porcelain"], stdout=" M file.py\n"),
     }
+    monkeypatch.setattr("dopetask.ops.tp_git.guards.assert_repo_identity", lambda repo_root: None)
     monkeypatch.setattr("dopetask.ops.tp_git.guards.run_git", _GitStub(outputs))
 
     with pytest.raises(RuntimeError, match="main has uncommitted changes"):
@@ -72,6 +75,7 @@ def test_doctor_refuses_stash(monkeypatch: pytest.MonkeyPatch) -> None:
         ("status", "--porcelain"): _result(["status", "--porcelain"], stdout=""),
         ("stash", "list"): _result(["stash", "list"], stdout="stash@{0}: WIP\n"),
     }
+    monkeypatch.setattr("dopetask.ops.tp_git.guards.assert_repo_identity", lambda repo_root: None)
     monkeypatch.setattr("dopetask.ops.tp_git.guards.run_git", _GitStub(outputs))
 
     with pytest.raises(RuntimeError, match="stash list is non-empty"):

--- a/tests/unit/tp_series/test_cli.py
+++ b/tests/unit/tp_series/test_cli.py
@@ -56,6 +56,8 @@ def _init_unborn_main_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
     (repo / "README.md").write_text("# repo\n", encoding="utf-8")
     (repo / ".dopetaskroot").write_text("", encoding="utf-8")
     (repo / ".dopetask").mkdir(parents=True, exist_ok=True)
@@ -69,10 +71,7 @@ def _init_unborn_main_repo(tmp_path: Path) -> Path:
 
 
 def _init_local_main_repo(tmp_path: Path) -> Path:
-    repo = _init_unborn_main_repo(tmp_path)
-    _git(repo, "config", "user.email", "test@example.com")
-    _git(repo, "config", "user.name", "Test User")
-    return repo
+    return _init_unborn_main_repo(tmp_path)
 
 
 def _write_packet(

--- a/tests/unit/tp_series/test_cli.py
+++ b/tests/unit/tp_series/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
@@ -37,7 +38,13 @@ def _init_repo_with_origin(tmp_path: Path) -> Path:
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "config", "user.name", "Test User")
     (repo / "README.md").write_text("# repo\n", encoding="utf-8")
-    _git(repo, "add", "README.md")
+    (repo / ".dopetaskroot").write_text("", encoding="utf-8")
+    (repo / ".dopetask").mkdir(parents=True, exist_ok=True)
+    (repo / ".dopetask" / "project.json").write_text(
+        json.dumps({"project_id": "dopetask.core"}, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "README.md", ".dopetaskroot", ".dopetask/project.json")
     _git(repo, "commit", "-m", "initial")
     _git(repo, "branch", "-M", "main")
     _git(repo, "remote", "add", "origin", str(remote))
@@ -49,6 +56,15 @@ def _init_unborn_main_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(repo, "init", "-b", "main")
+    (repo / "README.md").write_text("# repo\n", encoding="utf-8")
+    (repo / ".dopetaskroot").write_text("", encoding="utf-8")
+    (repo / ".dopetask").mkdir(parents=True, exist_ok=True)
+    (repo / ".dopetask" / "project.json").write_text(
+        json.dumps({"project_id": "dopetask.core"}, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "README.md", ".dopetaskroot", ".dopetask/project.json")
+    _git(repo, "commit", "-m", "initial")
     return repo
 
 
@@ -56,9 +72,6 @@ def _init_local_main_repo(tmp_path: Path) -> Path:
     repo = _init_unborn_main_repo(tmp_path)
     _git(repo, "config", "user.email", "test@example.com")
     _git(repo, "config", "user.name", "Test User")
-    (repo / "README.md").write_text("# repo\n", encoding="utf-8")
-    _git(repo, "add", "README.md")
-    _git(repo, "commit", "-m", "initial")
     return repo
 
 
@@ -72,6 +85,8 @@ def _write_packet(
     depends_on: list[str],
     parent_tp_id: str | None,
     final_packet: bool = False,
+    repo_binding: dict | None = None,
+    execution: dict | None = None,
 ) -> Path:
     payload = {
         "id": tp_id,
@@ -97,6 +112,10 @@ def _write_packet(
             "verify": ["git status --short"],
         },
     }
+    if repo_binding is not None:
+        payload["repo_binding"] = repo_binding
+    if execution is not None:
+        payload["execution"] = execution
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return path
 
@@ -556,11 +575,32 @@ def test_series_exec_refuses_unmet_dependencies(tmp_path: Path, monkeypatch) -> 
 
 
 def test_series_exec_refuses_unborn_main_without_initial_commit(tmp_path: Path, monkeypatch) -> None:
-    repo = _init_unborn_main_repo(tmp_path)
-    packet = tmp_path / "packet.json"
-    packet.write_text("{}\n", encoding="utf-8")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    packet = _write_packet(
+        tmp_path / "packet.json",
+        tp_id="TPUNBORN",
+        target="unborn",
+        series_id="SERIES-UNBORN",
+        allowlist=["src/unborn.txt"],
+        depends_on=[],
+        parent_tp_id=None,
+    )
 
     runner = CliRunner()
+    monkeypatch.setattr(
+        "dopetask.ops.tp_series.logic.load_repo_identity",
+        lambda repo_root: SimpleNamespace(
+            project_id="dopetask.core",
+            project_slug=None,
+            repo_remote_hint=None,
+            packet_required_header=False,
+        ),
+    )
+    monkeypatch.setattr("dopetask.ops.tp_series.logic.assert_repo_identity", lambda repo_root: None)
     monkeypatch.chdir(repo)
     result = runner.invoke(cli, ["tp", "series", "exec", str(packet), "--repo", str(repo)])
 
@@ -591,6 +631,34 @@ def test_series_exec_supports_local_main_without_origin(tmp_path: Path, monkeypa
     payload = json.loads(state_path.read_text(encoding="utf-8"))
     assert payload["packets"]["TPLOCAL"]["status"] == "completed"
     assert payload["packets"]["TPLOCAL"]["base_ref"] == "main"
+
+
+def test_series_exec_uses_execution_branch_when_present(tmp_path: Path, monkeypatch) -> None:
+    repo = _init_repo_with_origin(tmp_path)
+    packet = _write_packet(
+        tmp_path / "tp_branch.json",
+        tp_id="TPBRANCH",
+        target="branch override",
+        series_id="SERIES-BRANCH",
+        allowlist=["src/branch.txt"],
+        depends_on=[],
+        parent_tp_id=None,
+        execution={
+            "agent": "codex",
+            "branch": "series/SERIES-BRANCH/TPBRANCH",
+        },
+    )
+
+    monkeypatch.setattr("dopetask.ops.tp_series.logic.execute_task_packet", _fake_execute_task_packet)
+
+    runner = CliRunner()
+    monkeypatch.chdir(repo)
+    result = runner.invoke(cli, ["tp", "series", "exec", str(packet), "--repo", str(repo), "--agent", "codex"])
+
+    assert result.exit_code == 0, result.stdout
+    state_path = repo / "out" / "tp_series" / "SERIES-BRANCH" / "SERIES_STATE.json"
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["packets"]["TPBRANCH"]["branch"] == "series/SERIES-BRANCH/TPBRANCH"
 
 
 def test_series_finalize_requires_all_completed_packets_to_be_in_final_closure(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/tp_series/test_schema.py
+++ b/tests/unit/tp_series/test_schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 from dopetask.core.tp_parser import TPParser
+from dopetask.schemas.validator import validate_data
 
 
 def test_tp_parser_reads_series_and_commit_metadata(tmp_path) -> None:
@@ -15,6 +16,12 @@ def test_tp_parser_reads_series_and_commit_metadata(tmp_path) -> None:
                 "id": "TPX",
                 "target": "series packet",
                 "steps": [{"id": "s1", "task": "run", "validation": ["true"]}],
+                "repo_binding": {
+                    "project_id": "dopetask.core",
+                    "repo_marker": ".dopetaskroot",
+                    "origin_hint": "git@github.com:example/dopetask.git",
+                    "require_identity_match": True,
+                },
                 "depends_on": ["TPA"],
                 "series": {
                     "id": "SERIES-X",
@@ -22,10 +29,23 @@ def test_tp_parser_reads_series_and_commit_metadata(tmp_path) -> None:
                     "parent_tp_id": "TPA",
                     "final_packet": False,
                 },
+                "execution": {
+                    "agent": "gemini",
+                    "branch": "series/SERIES-X/TPX",
+                },
+                "pal_chain": {
+                    "enabled": True,
+                    "steps": ["analysis"],
+                },
                 "commit": {
                     "message": "TPX: commit",
                     "allowlist": ["src/x.txt"],
                     "verify": ["git status --short"],
+                },
+                "pr": {
+                    "title": "Series X",
+                    "body": "Ready for review.",
+                    "base": "main",
                 },
             }
         ),
@@ -38,6 +58,154 @@ def test_tp_parser_reads_series_and_commit_metadata(tmp_path) -> None:
     assert parsed.series is not None
     assert parsed.series.id == "SERIES-X"
     assert parsed.series.parent_tp_id == "TPA"
+    assert parsed.repo_binding is not None
+    assert parsed.repo_binding.project_id == "dopetask.core"
+    assert parsed.execution is not None
+    assert parsed.execution.branch == "series/SERIES-X/TPX"
     assert parsed.commit is not None
     assert parsed.commit.allowlist == ["src/x.txt"]
+    assert parsed.pr is not None
+    assert parsed.pr["title"] == "Series X"
 
+
+def test_strict_task_packet_schema_accepts_non_gemini_with_pal_chain() -> None:
+    packet = {
+        "id": "TPX",
+        "project": "dopetask",
+        "target": "strict packet",
+        "invariants": ["keep repo identity matched"],
+        "repo_binding": {
+            "project_id": "dopetask.core",
+            "repo_marker": ".dopetaskroot",
+            "require_identity_match": True,
+        },
+        "series": {
+            "id": "SERIES-X",
+            "base_branch": "main",
+            "parent_tp_id": None,
+            "final_packet": True,
+        },
+        "execution": {
+            "agent": "codex",
+            "branch": "series/SERIES-X/TPX",
+        },
+        "commit": {
+            "message": "TPX: commit",
+            "allowlist": ["src/x.txt"],
+            "verify": ["git status --short"],
+        },
+        "pr": {
+            "title": "SERIES-X: strict packet",
+            "body": "Ready for review.",
+            "base": "main",
+        },
+        "pal_chain": {
+            "enabled": False,
+            "steps": ["analysis"],
+        },
+        "steps": [
+            {
+                "id": "s1",
+                "task": "run",
+                "validation": ["true"],
+            }
+        ],
+    }
+
+    ok, errors = validate_data(packet, "task_packet.strict", strict=False)
+
+    assert ok is True
+    assert errors == []
+
+
+def test_strict_task_packet_schema_requires_enabled_pal_chain_for_gemini() -> None:
+    packet = {
+        "id": "TPX",
+        "project": "dopetask",
+        "target": "strict packet",
+        "invariants": ["keep repo identity matched"],
+        "repo_binding": {
+            "project_id": "dopetask.core",
+            "repo_marker": ".dopetaskroot",
+            "require_identity_match": True,
+        },
+        "series": {
+            "id": "SERIES-X",
+            "base_branch": "main",
+            "parent_tp_id": None,
+            "final_packet": True,
+        },
+        "execution": {
+            "agent": "gemini",
+            "branch": "series/SERIES-X/TPX",
+        },
+        "commit": {
+            "message": "TPX: commit",
+            "allowlist": ["src/x.txt"],
+            "verify": ["git status --short"],
+        },
+        "pr": {
+            "title": "SERIES-X: strict packet",
+            "body": "Ready for review.",
+            "base": "main",
+        },
+        "pal_chain": {
+            "enabled": False,
+            "steps": ["analysis"],
+        },
+        "steps": [
+            {
+                "id": "s1",
+                "task": "run",
+                "validation": ["true"],
+            }
+        ],
+    }
+
+    ok, errors = validate_data(packet, "task_packet.strict", strict=False)
+
+    assert ok is False
+    assert any("pal_chain" in error for error in errors)
+
+
+def test_strict_task_packet_schema_requires_execution_and_commit_verify() -> None:
+    packet = {
+        "id": "TPX",
+        "project": "dopetask",
+        "target": "strict packet",
+        "invariants": ["keep repo identity matched"],
+        "repo_binding": {
+            "project_id": "dopetask.core",
+            "repo_marker": ".dopetaskroot",
+            "require_identity_match": True,
+        },
+        "series": {
+            "id": "SERIES-X",
+            "base_branch": "main",
+            "parent_tp_id": None,
+            "final_packet": True,
+        },
+        "commit": {
+            "message": "TPX: commit",
+            "allowlist": ["src/x.txt"],
+            "verify": [],
+        },
+        "pr": {
+            "title": "SERIES-X: strict packet",
+            "body": "Ready for review.",
+            "base": "main",
+        },
+        "steps": [
+            {
+                "id": "s1",
+                "task": "run",
+                "validation": ["true"],
+            }
+        ],
+    }
+
+    ok, errors = validate_data(packet, "task_packet.strict", strict=False)
+
+    assert ok is False
+    assert any("execution" in error for error in errors)
+    assert any("verify" in error for error in errors)


### PR DESCRIPTION
## Summary
- Adds a packaged strict Task Packet schema for repo-bound work with required repo binding, execution metadata, commit verification, PR metadata, and Gemini PAL enforcement.
- Updates prompt export, repo instruction templates, and setup/install docs so new repos are taught the strict contract by default.
- Adds regression coverage for schema discovery, strict validation, prompt export, and project-init emission.

## Validation
- `python -m compileall src tests`
- `pytest -q tests/unit/test_schema_registry.py tests/unit/tp_series/test_schema.py tests/unit/project/test_init.py tests/ops/test_ops.py tests/ops/test_flash_hardening.py`
- `python -m dopetask ops --help`
- `python -m dopetask tp series --help`
- `python -m dopetask doctor --help`

## Notes
- The full `pytest -q` suite still hits an unrelated pre-existing drift in `tests/unit/obs/test_proof_contract_assets.py::test_checked_in_archive_manifests_match_standard_schema` because a checked-in proof archive manifest contains `source_path`, which that schema rejects.
